### PR TITLE
Fix message signature analyzer with multiple definitions of the same message

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/MessageSignatureTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/MessageSignatureTests.cs
@@ -40,5 +40,36 @@ class Camera : MonoBehaviour
 ";
 			await Verify.VerifyCodeFixAsync(test, diagnostic, fixedTest);
 		}
+
+		[Fact]
+		public async Task MessageSignatureWithInheritance()
+		{
+			// two declarations for OnDestroy (one in EditorWindow and one in ScriptableObject) 
+			const string test = @"
+using UnityEditor;
+
+class TestWindow : EditorWindow
+{
+    private void OnDestroy(int foo)
+    {
+    }
+}
+";
+
+			var diagnostic = Verify.Diagnostic().WithLocation(6, 18).WithArguments("OnDestroy");
+
+			const string fixedTest = @"
+using UnityEditor;
+
+class TestWindow : EditorWindow
+{
+    private void OnDestroy()
+    {
+    }
+}
+";
+			await Verify.VerifyCodeFixAsync(test, diagnostic, fixedTest);
+		}
+
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/MessageSignature.cs
+++ b/src/Microsoft.Unity.Analyzers/MessageSignature.cs
@@ -55,18 +55,20 @@ namespace Microsoft.Unity.Analyzers
 			var methods = classDeclaration.Members.OfType<MethodDeclarationSyntax>();
 			var messages = scriptInfo
 				.GetMessages()
-				.ToDictionary(m => m.Name);
+				.ToLookup(m => m.Name);
 
 			foreach (var method in methods)
 			{
-				if (!messages.TryGetValue(method.Identifier.Text, out var message))
+				var methodName = method.Identifier.Text;
+
+				if (!messages.Contains(methodName))
 					continue;
 
 				var methodSymbol = context.SemanticModel.GetDeclaredSymbol(method);
 				if (scriptInfo.IsMessage(methodSymbol))
 					continue;
 
-				context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation(), message.Name));
+				context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation(), methodName));
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #2 

#### Checklist
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] I have added tests that prove my fix is effective or that my feature works ;

#### Short description of what this resolves:
With ScriptInfo.GetMessages(), we can find "duplicate" messages like OnDestroy, used on contexts like EditorWindow and ScriptableObject.

#### Changes proposed in this pull request:
Use a lookup instead of a dictionary to quickly filter non-messages, while being able to handle duplicates.