### PR TITLE
Add USP0008 suppressor for IDE0051, for methods invoked using InvokeMethod/StartCoroutine

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -25,3 +25,4 @@ USP0004 | IDE0044 | Don't set fields with a SerializeField attribute to read-onl
 USP0005 | IDE0060 | The Unity runtime invokes Unity messages
 USP0006 | IDE0051 | Don't flag private fields with a SerializeField attribute as unused
 USP0007 | CS0649 | Don't flag fields with a SerializeField attribute as never assigned
+USP0008 | IDE0051 | Don't flag private methods used with Invoke/InvokeRepeating or StartCoroutine/StopCoroutine as unused

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -493,6 +493,15 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t flag private methods used with Invoke/InvokeRepeating or StartCoroutine/StopCoroutine as unused..
+        /// </summary>
+        internal static string UnusedMethodSuppressorJustification {
+            get {
+                return ResourceManager.GetString("UnusedMethodSuppressorJustification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Don&apos;t flag private fields with a SerializeField attribute as unused..
         /// </summary>
         internal static string UnusedSerializeFieldSuppressorJustification {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -276,4 +276,7 @@
   <data name="NeverAssignedSerializeFieldSuppressorJustification" xml:space="preserve">
     <value>Don't flag fields with a SerializeField attribute as never assigned.</value>
   </data>
+  <data name="UnusedMethodSuppressorJustification" xml:space="preserve">
+    <value>Don't flag private methods used with Invoke/InvokeRepeating or StartCoroutine/StopCoroutine as unused.</value>
+  </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/UnusedMethodSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/UnusedMethodSuppressor.cs
@@ -1,0 +1,89 @@
+﻿/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Unity.Analyzers.Resources;
+
+namespace Microsoft.Unity.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class UnusedMethodSuppressor : DiagnosticSuppressor
+	{
+		private static readonly SuppressionDescriptor Rule = new SuppressionDescriptor(
+			id: "USP0008",
+			suppressedDiagnosticId: "IDE0051",
+			justification: Strings.UnusedMethodSuppressorJustification);
+
+		public override void ReportSuppressions(SuppressionAnalysisContext context)
+		{
+			foreach (var diagnostic in context.ReportedDiagnostics)
+			{
+				AnalyzeDiagnostic(diagnostic, context);
+			}
+		}
+
+		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(Rule);
+
+		private static readonly HashSet<string> MethodNames = new HashSet<string>(new[] {"Invoke", "InvokeRepeating", "StartCoroutine", "StopCoroutine"});
+
+		private static void AnalyzeDiagnostic(Diagnostic diagnostic, SuppressionAnalysisContext context)
+		{
+			var sourceTree = diagnostic.Location.SourceTree;
+			var root = sourceTree.GetRoot(context.CancellationToken);
+			var node = root.FindNode(diagnostic.Location.SourceSpan);
+
+			if (!(node is MethodDeclarationSyntax method))
+				return;
+
+			var model = context.GetSemanticModel(diagnostic.Location.SourceTree);
+			if (!(model.GetDeclaredSymbol(method) is IMethodSymbol methodSymbol))
+				return;
+
+			var typeSymbol = methodSymbol.ContainingType;
+			if (!typeSymbol.Extends(typeof(UnityEngine.MonoBehaviour)))
+				return;
+
+			var references = root
+				.DescendantNodes()
+				.OfType<InvocationExpressionSyntax>()
+				.Where(e => IsMatchingArgument(e, methodSymbol.Name))
+				.Where(e => IsMatchingIdentifier(e.Expression));
+
+			if (references.Any())
+				context.ReportSuppression(Suppression.Create(Rule, diagnostic));
+		}
+
+		private static bool IsMatchingIdentifier(SyntaxNode sn)
+		{
+			switch (sn)
+			{
+				case MemberAccessExpressionSyntax maes:
+					return IsMatchingIdentifier(maes.Name);
+				case IdentifierNameSyntax ins:
+					return MethodNames.Contains(ins.Identifier.Text);
+				default:
+					return false;
+			}
+		}
+
+		private static bool IsMatchingArgument(InvocationExpressionSyntax ies, string name)
+		{
+			var args = ies.ArgumentList.Arguments;
+
+			if (args.Count <= 0)
+				return false;
+
+			if (!(args.First().Expression is LiteralExpressionSyntax les))
+				return false;
+
+			return name == les.Token.ValueText;
+		}
+	}
+}


### PR DESCRIPTION
Add `USP0008` suppressor for `IDE0051`, for methods invoked using InvokeMethod/StartCoroutine

Fixes #4 

#### Checklist
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Suppress IDE0051 for target methods when we detect an invocation to:
- InvokeMethod
- InvokeRepeating
- StartCoroutine
- StopCoroutine

#### Changes proposed in this pull request:
- Added `USP0008` suppressor
- Added resources
