### PR TITLE
Handles new analyzer generation when there exists multiple analyzer I…

### DIFF
--- a/src/new-analyzer/Program.cs
+++ b/src/new-analyzer/Program.cs
@@ -238,7 +238,7 @@ class Camera : MonoBehaviour
 				}
 			}
 
-			return identifier != 1;
+			return identifier != -1;
 		}
 
 		private static bool TryExtractIdentifier(string line, out int identifier)


### PR DESCRIPTION
Fixes #6.

I don't believe there are tests of any sort for 'new-analyzer'. Is that correct?

Handles new analyzer generation when there are multiple analyzer IDs in a single class. 

Fixed by returning the maximum ID in any given class instead of the first one we find.