### PR TITLE
Unused coroutine return value analyzer

### DIFF
--- a/doc/UNT0012.md
+++ b/doc/UNT0012.md
@@ -1,0 +1,53 @@
+# UNT0012 Unused Coroutine Return Value
+
+Wrap calls to coroutines in StartCoroutine(). Failure to do so will result in the coroutine not being executed.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using System.Collections;
+using UnityEngine;
+
+public class UnusedCoroutineScript : MonoBehaviour
+{
+    void Start()
+    {
+        UnusedCoroutine(2.0f);
+    }
+
+    private IEnumerator UnusedCoroutine(float waitTime)
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            yield return new WaitForSeconds(waitTime);
+        }
+    }
+}
+```
+
+## Solution
+
+Wrap calls to coroutines in StartCoroutine():
+
+```csharp
+using System.Collections;
+using UnityEngine;
+
+public class UnusedCoroutineScript : MonoBehaviour
+{
+    void Start()
+    {
+        StartCoroutine(UnusedCoroutine(2.0f));
+    }
+
+    private IEnumerator UnusedCoroutine(float waitTime)
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            yield return new WaitForSeconds(waitTime);
+        }
+    }
+}
+```
+
+A code fix is offered for this diagnostic to automatically apply this change.

--- a/doc/index.md
+++ b/doc/index.md
@@ -13,6 +13,7 @@ ID | Title | Category
 [UNT0009](UNT0009.md) | Missing static constructor with InitializeOnLoad | Correctness
 [UNT0010](UNT0010.md) | MonoBehaviour instance creation | Type Safety
 [UNT0011](UNT0011.md) | ScriptableObject instance creation | Type Safety
+[UNT0012](UNT0012.md) | Unused coroutine return value | Correctness
 
 # Diagnostic Suppressors
 

--- a/src/Microsoft.Unity.Analyzers.Tests/UnityAnalyzerVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityAnalyzerVerifier.cs
@@ -37,23 +37,25 @@ namespace Microsoft.Unity.Analyzers.Tests
 
 		protected static IEnumerable<string> UnityAssemblies()
 		{
-			var installation = UnityPath.FirstInstallation();
-			string installationFullPath = null;
+			var firstInstallationPath = UnityPath.FirstInstallation();
+			string installationFullPath = firstInstallationPath;
 
 			if (UnityPath.OnWindows())
-				installationFullPath = Path.Combine(installation, "Editor", "Data");
-
-			// Unity installation might be within the Hub directory for Unity Hub installations
-			if (!Directory.Exists(installationFullPath))
 			{
-				string installationHubDirectory = Path.Combine(installation, "Hub", "Editor");
-				string editorVersion;
-				if (Directory.Exists(installationHubDirectory))
+				installationFullPath = Path.Combine(firstInstallationPath, "Editor", "Data");
+
+				// Unity installation might be within the Hub directory for Unity Hub installations
+				if (!Directory.Exists(installationFullPath))
 				{
-					editorVersion = Directory.GetDirectories(installationHubDirectory).FirstOrDefault();
-					if (editorVersion != null)
+					string installationHubDirectory = Path.Combine(firstInstallationPath, "Hub", "Editor");
+					string editorVersion;
+					if (Directory.Exists(installationHubDirectory))
 					{
-						installationFullPath = Path.Combine(installationHubDirectory, editorVersion, "Editor", "Data");
+						editorVersion = Directory.GetDirectories(installationHubDirectory).FirstOrDefault();
+						if (editorVersion != null)
+						{
+							installationFullPath = Path.Combine(installationHubDirectory, editorVersion, "Editor", "Data");
+						}
 					}
 				}
 			}

--- a/src/Microsoft.Unity.Analyzers.Tests/UnityAnalyzerVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityAnalyzerVerifier.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.Unity.Analyzers.Tests
@@ -37,12 +38,32 @@ namespace Microsoft.Unity.Analyzers.Tests
 		protected static IEnumerable<string> UnityAssemblies()
 		{
 			var installation = UnityPath.FirstInstallation();
-			if (UnityPath.OnWindows())
-				installation = Path.Combine(installation, "Editor", "Data");
+			string installationFullPath = null;
 
-			var managed = Path.Combine(installation, "Managed");
-			yield return Path.Combine(managed, "UnityEditor.dll");
-			yield return Path.Combine(managed, "UnityEngine.dll");
+			if (UnityPath.OnWindows())
+				installationFullPath = Path.Combine(installation, "Editor", "Data");
+
+			// Unity installation might be within the Hub directory for Unity Hub installations
+			if (!Directory.Exists(installationFullPath))
+			{
+				string installationHubDirectory = Path.Combine(installation, "Hub", "Editor");
+				string editorVersion;
+				if (Directory.Exists(installationHubDirectory))
+				{
+					editorVersion = Directory.GetDirectories(installationHubDirectory).FirstOrDefault();
+					if (editorVersion != null)
+					{
+						installationFullPath = Path.Combine(installationHubDirectory, editorVersion, "Editor", "Data");
+					}
+				}
+			}
+
+			if (Directory.Exists(installationFullPath))
+			{
+				var managed = Path.Combine(installationFullPath, "Managed");
+				yield return Path.Combine(managed, "UnityEditor.dll");
+				yield return Path.Combine(managed, "UnityEngine.dll");
+			}
 		}
 
 		public class UnityAnalyzerTest : CSharpAnalyzerTest<TAnalyzer, XUnitVerifier>

--- a/src/Microsoft.Unity.Analyzers.Tests/UnusedCoroutineReturnValueTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnusedCoroutineReturnValueTests.cs
@@ -8,23 +8,49 @@ namespace Microsoft.Unity.Analyzers.Tests
 	public class UnusedCoroutineReturnValueTests
 	{
 		[Fact]
-		public async Task Test ()
+		public async Task UnusedCoroutineReturnValueTest()
 		{
 			const string test = @"
+using System.Collections;
 using UnityEngine;
 
-class Camera : MonoBehaviour
+public class UnusedCoroutineScript : MonoBehaviour
 {
+    void Start()
+    {
+        UnusedCoroutine(2.0f);
+    }
+
+    private IEnumerator UnusedCoroutine(float waitTime)
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            yield return new WaitForSeconds(waitTime);
+        }
+    }
 }
 ";
 
-			var diagnostic = Verify.Diagnostic();
+			var diagnostic = Verify.Diagnostic(UnusedCoroutineReturnValueAnalyzer.Id).WithLocation(9, 9).WithArguments("UnusedCoroutine");
 
 			const string fixedTest = @"
+using System.Collections;
 using UnityEngine;
 
-class Camera : MonoBehaviour
+public class UnusedCoroutineScript : MonoBehaviour
 {
+    void Start()
+    {
+        StartCoroutine(UnusedCoroutine(2.0f));
+    }
+
+    private IEnumerator UnusedCoroutine(float waitTime)
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            yield return new WaitForSeconds(waitTime);
+        }
+    }
 }
 ";
 			await Verify.VerifyCodeFixAsync(test, diagnostic, fixedTest);

--- a/src/Microsoft.Unity.Analyzers.Tests/UnusedCoroutineReturnValueTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnusedCoroutineReturnValueTests.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests
+{
+	using Verify = UnityCodeFixVerifier<UnusedCoroutineReturnValueAnalyzer, UnusedCoroutineReturnValueCodeFix>;
+
+	public class UnusedCoroutineReturnValueTests
+	{
+		[Fact]
+		public async Task Test ()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+}
+";
+
+			var diagnostic = Verify.Diagnostic();
+
+			const string fixedTest = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+}
+";
+			await Verify.VerifyCodeFixAsync(test, diagnostic, fixedTest);
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -484,6 +484,42 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use StartCoroutine().
+        /// </summary>
+        internal static string UnusedCoroutineReturnValueCodeFixTitle {
+            get {
+                return ResourceManager.GetString("UnusedCoroutineReturnValueCodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use StartCoroutine() to start a coroutine. Calling the coroutine method directly will result in the coroutine never being executed..
+        /// </summary>
+        internal static string UnusedCoroutineReturnValueDiagnosticDescription {
+            get {
+                return ResourceManager.GetString("UnusedCoroutineReturnValueDiagnosticDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Coroutine {0} should be called using StartCoroutine()..
+        /// </summary>
+        internal static string UnusedCoroutineReturnValueDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("UnusedCoroutineReturnValueDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unused Unity Coroutine.
+        /// </summary>
+        internal static string UnusedCoroutineReturnValueDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("UnusedCoroutineReturnValueDiagnosticTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The Unity runtime invokes Unity messages..
         /// </summary>
         internal static string UnusedMessageSuppressorJustification {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -279,4 +279,16 @@
   <data name="UnusedMethodSuppressorJustification" xml:space="preserve">
     <value>Don't flag private methods used with Invoke/InvokeRepeating or StartCoroutine/StopCoroutine as unused.</value>
   </data>
+  <data name="UnusedCoroutineReturnValueCodeFixTitle" xml:space="preserve">
+    <value>Use StartCoroutine()</value>
+  </data>
+  <data name="UnusedCoroutineReturnValueDiagnosticDescription" xml:space="preserve">
+    <value>Use StartCoroutine() to start a coroutine. Calling the coroutine method directly will result in the coroutine never being executed.</value>
+  </data>
+  <data name="UnusedCoroutineReturnValueDiagnosticMessageFormat" xml:space="preserve">
+    <value>Coroutine {0} should be called using StartCoroutine().</value>
+  </data>
+  <data name="UnusedCoroutineReturnValueDiagnosticTitle" xml:space="preserve">
+    <value>Unused Unity Coroutine</value>
+  </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/UnusedCoroutineReturnValue.cs
+++ b/src/Microsoft.Unity.Analyzers/UnusedCoroutineReturnValue.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Unity.Analyzers.Resources;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Unity.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class UnusedCoroutineReturnValueAnalyzer : DiagnosticAnalyzer
+	{
+		public const string Id = "UNT0012";
+
+		private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			Id,
+			title: Strings.UnusedCoroutineReturnValueDiagnosticTitle,
+			messageFormat: Strings.UnusedCoroutineReturnValueDiagnosticMessageFormat,
+			category: DiagnosticCategory.Correctness,
+			defaultSeverity: DiagnosticSeverity.Info,
+			isEnabledByDefault: true,
+			description: Strings.UnusedCoroutineReturnValueDiagnosticDescription);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		private static readonly Type coroutineReturnValue = typeof(System.Collections.IEnumerable);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+		}
+
+		private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+		{
+			var typeInfo = context.Compilation.GetTypeByMetadataName("System.Collections.IEnumerator");
+			
+			var invocation = (InvocationExpressionSyntax)context.Node;
+			var symbol = context.SemanticModel.GetSymbolInfo(invocation);
+			if (symbol.Symbol == null)
+				return;
+
+			if (!IsValidCoroutine(symbol.Symbol, typeInfo, out var methodName))
+				return;
+
+			if (!invocation.Parent.IsKind(SyntaxKind.ExpressionStatement))
+				return;
+
+			context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), methodName));
+		}
+
+		private static bool IsValidCoroutine(ISymbol symbol, INamedTypeSymbol typeInfo, out string methodName)
+		{
+			methodName = null;
+			if (!(symbol is IMethodSymbol method))
+				return false;
+
+			var containingType = method.ContainingType;
+			if (!containingType.Extends(typeof(UnityEngine.MonoBehaviour)))
+				return false;
+
+			if (!Equals(method.ReturnType, typeInfo))
+				return false;
+
+			methodName = method.Name;
+			return true;
+		}
+	}
+
+	[ExportCodeFixProvider(LanguageNames.CSharp)]
+	public class UnusedCoroutineReturnValueCodeFix : CodeFixProvider
+	{
+		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(UnusedCoroutineReturnValueAnalyzer.Id);
+
+		public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+			if (!(root.FindNode(context.Span) is InvocationExpressionSyntax invocation))
+				return;
+
+			var parent = invocation.Parent;
+			if (!parent.IsKind(SyntaxKind.ExpressionStatement))
+				return;
+
+			context.RegisterCodeFix(
+				CodeAction.Create(
+					Strings.UnusedCoroutineReturnValueCodeFixTitle,
+					ct => WrapWithStartCoroutine(context.Document, parent, invocation, ct),
+					invocation.ToFullString()),
+				context.Diagnostics);
+		}
+
+		private static async Task<Document> WrapWithStartCoroutine(Document document, 
+			SyntaxNode parent, 
+			InvocationExpressionSyntax invocation, 
+			CancellationToken cancellationToken)
+		{
+			var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+			// Expression Statement -> InvocationExpression -> ArgumentList -> Argument -> old InvocationExpression
+			var newExpressionStatement = ExpressionStatement(
+				InvocationExpression(
+					IdentifierName("StartCoroutine"), 
+					ArgumentList(
+						SingletonSeparatedList<ArgumentSyntax>(
+							Argument(invocation)))));
+
+			var newRoot = root.ReplaceNode(parent, newExpressionStatement);
+			return document.WithSyntaxRoot(newRoot);
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/UnusedCoroutineReturnValue.cs
+++ b/src/Microsoft.Unity.Analyzers/UnusedCoroutineReturnValue.cs
@@ -109,7 +109,6 @@ namespace Microsoft.Unity.Analyzers
 		{
 			var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
-			// Expression Statement -> InvocationExpression -> ArgumentList -> Argument -> old InvocationExpression
 			var newExpressionStatement = ExpressionStatement(
 				InvocationExpression(
 					IdentifierName("StartCoroutine"), 


### PR DESCRIPTION
Fixes #12.

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Adds an analyzer to detect and fix direct calls to coroutines, where their return value is unused. Such calls will not be executed.

#### Changes proposed in this pull request:
Provides a code fix that wraps the call to a coroutine in StartCoroutine().
