### PR TITLE
Add support for SerializeReference

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -21,8 +21,8 @@ ID | Suppressed ID | Justification
 USP0001 | IDE0029 | Unity objects should not use null coalescing
 USP0002 | IDE0031 | Unity objects should not use null propagation
 USP0003 | IDE0051 | The Unity runtime invokes Unity messages
-USP0004 | IDE0044 | Don't set fields with a SerializeField attribute to read-only
+USP0004 | IDE0044 | Don't set fields with a SerializeField or SerializeReference attributes to read-only
 USP0005 | IDE0060 | The Unity runtime invokes Unity messages
-USP0006 | IDE0051 | Don't flag private fields with a SerializeField attribute as unused
-USP0007 | CS0649 | Don't flag fields with a SerializeField attribute as never assigned
+USP0006 | IDE0051 | Don't flag private fields with a SerializeField or SerializeReference attributes as unused
+USP0007 | CS0649 | Don't flag fields with a SerializeField or SerializeReference attributes as never assigned
 USP0008 | IDE0051 | Don't flag private methods used with Invoke/InvokeRepeating or StartCoroutine/StopCoroutine as unused

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -304,7 +304,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Don&apos;t flag fields with a SerializeField attribute as never assigned..
+        ///   Looks up a localized string similar to Don&apos;t flag fields with a SerializeField or SerializeReference attribute as never assigned..
         /// </summary>
         internal static string NeverAssignedSerializeFieldSuppressorJustification {
             get {
@@ -349,7 +349,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Don&apos;t set fields with a SerializeField attribute to read-only..
+        ///   Looks up a localized string similar to Don&apos;t set fields with a SerializeField or SerializeReference attributes to read-only..
         /// </summary>
         internal static string ReadonlySerializeFieldSuppressorJustification {
             get {
@@ -502,7 +502,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Don&apos;t flag private fields with a SerializeField attribute as unused..
+        ///   Looks up a localized string similar to Don&apos;t flag private fields with a SerializeField or SerializeReference attribute as unused..
         /// </summary>
         internal static string UnusedSerializeFieldSuppressorJustification {
             get {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -268,13 +268,13 @@
     <value>The Unity runtime invokes Unity messages.</value>
   </data>
   <data name="ReadonlySerializeFieldSuppressorJustification" xml:space="preserve">
-    <value>Don't set fields with a SerializeField attribute to read-only.</value>
+    <value>Don't set fields with a SerializeField or SerializeReference attributes to read-only.</value>
   </data>
   <data name="UnusedSerializeFieldSuppressorJustification" xml:space="preserve">
-    <value>Don't flag private fields with a SerializeField attribute as unused.</value>
+    <value>Don't flag private fields with a SerializeField or SerializeReference attribute as unused.</value>
   </data>
   <data name="NeverAssignedSerializeFieldSuppressorJustification" xml:space="preserve">
-    <value>Don't flag fields with a SerializeField attribute as never assigned.</value>
+    <value>Don't flag fields with a SerializeField or SerializeReference attribute as never assigned.</value>
   </data>
   <data name="UnusedMethodSuppressorJustification" xml:space="preserve">
     <value>Don't flag private methods used with Invoke/InvokeRepeating or StartCoroutine/StopCoroutine as unused.</value>

--- a/src/Microsoft.Unity.Analyzers/SerializeFieldSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/SerializeFieldSuppressor.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Unity.Analyzers
 			if (!(model.GetDeclaredSymbol(node) is IFieldSymbol fieldSymbol))
 				return;
 
-			if (!fieldSymbol.GetAttributes().Any(a => a.AttributeClass.Matches(typeof(UnityEngine.SerializeField))))
+			if (!fieldSymbol.GetAttributes().Any(a => a.AttributeClass.Matches(typeof(UnityEngine.SerializeField)) || a.AttributeClass.Matches(typeof(UnityEngine.SerializeReference))))
 				return;
 
 			foreach (var descriptor in SupportedSuppressions.Where(d => d.SuppressedDiagnosticId == diagnostic.Id))

--- a/src/Microsoft.Unity.Analyzers/UnityStubs.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityStubs.cs
@@ -186,6 +186,10 @@ namespace UnityEngine
 	class SerializeField : System.Attribute
 	{
 	}
+
+	class SerializeReference : System.Attribute
+	{
+	}
 }
 
 namespace UnityEngine.EventSystems


### PR DESCRIPTION
Fixes #11 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [ ] I have added tests that prove my fix is effective or that my feature works; (N/A, suppressor tests are not currently supported)
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Adds support for SerializeReference to our existing SerializeField suppressor

#### Changes proposed in this pull request:
- Change `SerializeFieldSuppressor` to support the new `SerializeReference` attribute
- Adjust relevant docs and strings

#### Other Notes:
Our suppressors currently fail to suppress CS0649. It's not clear if this ever worked for SerializeField. I've filed #15 to fix whatever the underlying issue is, which should light up CS0649 suppression in this case as well.