### PR TITLE
Add an mpack project to develop and debug analyzers on VSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build status on Windows](https://github.com/microsoft/Microsoft.Unity.Analyzers/workflows/CI-Windows/badge.svg)](https://github.com/microsoft/Microsoft.Unity.Analyzers/actions?query=workflow%3ACI-Windows)
 [![Build status on macOS](https://github.com/microsoft/Microsoft.Unity.Analyzers/workflows/CI-macOS/badge.svg)](https://github.com/microsoft/Microsoft.Unity.Analyzers/actions?query=workflow%3ACI-macOS)
 
-This project is intended to provide to Visual Studio a better understanding of Unity projects by adding new Unity-specific diagnostics or by removing general C# diagnostics that do not apply to Unity projects. 
+This project provides Visual Studio with a better understanding of Unity projects by adding Unity-specific diagnostics or by removing general C# diagnostics that do not apply to Unity projects. 
 
 Check out the [list of analyzers and suppressors](doc/index.md) defined in this project.
 
@@ -12,30 +12,39 @@ If you have an idea for a best practice for Unity developers to follow, please o
 # Prerequisites
 For building and testing, you'll need the .NET Core SDK. We recommend using the **.NET Core SDK Version 3.1.100 (LTS)** or later.
 
-This project is using the `DiagnosticSuppressor` API to conditionally suppress reported compiler/analyzer diagnostics. This API is available starting with **Visual Studio 2019 16.3** or **Visual Studio for Mac 8.3**. On Windows, you'll need the _Visual Studio extension development_ workload installed to build a VSIX to use and debug the project in Visual Studio.
+This project is using the `DiagnosticSuppressor` API to conditionally suppress reported compiler/analyzer diagnostics. This API is available starting with **Visual Studio 2019 16.3** or **Visual Studio for Mac 8.3**.
+
+On Windows, you'll need the _Visual Studio extension development_ workload installed to build a VSIX to use and debug the project in Visual Studio.
 
 For unit-testing, we require Unity to be installed. We recommend using the latest LTS version for that.
 
 # Building and testing
 
-Everything can be compiled and deployed using the command line:
+Compiling the solution:
+`dotnet build .\src\Microsoft.Unity.Analyzers.sln`
 
-Compiling the main project only:
-`dotnet build .\src\Microsoft.Unity.Analyzers`
+Running the unit tests:
+`dotnet test .\src\Microsoft.Unity.Analyzers.sln`
 
-Unit-Testing:
-`dotnet test .\src\Microsoft.Unity.Analyzers.Tests`
+You can open `.\src\Microsoft.Unity.Analyzers.sln` in your favorite IDE to work on the analyzers and run/debug the tests.
 
-Compiling all projects and deploying analyzers/suppressors as a VSIX extension into the Visual Studio Experimental Instance:
-`msbuild .\src\Microsoft.Unity.Analyzers.sln`
+# Debugging the analyzers on a Unity project
 
-# Debugging
+Running and debugging the tests is the easiest way to get started but sometimes you want to work on a real-life Unity project.
 
-The easiest way to compile and debug interactively is to use Visual Studio 2019 :
-- Load the `Microsoft.Unity.Analyzers.sln` solution.
-- Set `Microsoft.Unity.Analyzers.Vsix` as your startup project.
+## On Windows
+
+- Open the `Microsoft.Unity.Analyzers.Vsix.sln` solution.
+- Make sure `Microsoft.Unity.Analyzers.Vsix` is set as the startup project.
 - Hit play (Current Instance) to start debugging an experimental instance of Visual Studio 2019.
-- Load any Unity project in the VS experimental instance then put breakpoints in the Analyzer project using the VS main instance.
+- Load any Unity project in the Visual Studio experimental instance then put breakpoints in the `Microsoft.Unity.Analyzers` project.
+
+## On macOS
+
+- Open the `Microsoft.Unity.Analyzers.Mpack.sln` solution.
+- Make sure `Microsoft.Unity.Analyzers.Mpack` is set as the startup project.
+- Hit play to start debugging an experimental instance of Visual Studio for Mac.
+- Load any Unity project in the Visual Studio for Mac experimental instance then put breakpoints in the `Microsoft.Unity.Analyzers` project.
 
 # Handling duplicate diagnostics 
 

--- a/src/Microsoft.Unity.Analyzers.Mpack.sln
+++ b/src/Microsoft.Unity.Analyzers.Mpack.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29102.190
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Unity.Analyzers.Mpack", "Microsoft.Unity.Analyzers.Mpack\Microsoft.Unity.Analyzers.Mpack.csproj", "{75C9E697-F3D8-438A-9C31-802DF27867B2}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Unity.Analyzers", "Microsoft.Unity.Analyzers\Microsoft.Unity.Analyzers.csproj", "{3352E64B-4789-46A3-A589-BDA698379164}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Unity.Analyzers.Tests", "Microsoft.Unity.Analyzers.Tests\Microsoft.Unity.Analyzers.Tests.csproj", "{253C9CCC-B9BD-4137-AC93-E73EF7E4AAA7}"
@@ -27,6 +29,10 @@ Global
 		{671EB45F-5783-41EF-831C-25EED97670C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{671EB45F-5783-41EF-831C-25EED97670C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{671EB45F-5783-41EF-831C-25EED97670C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75C9E697-F3D8-438A-9C31-802DF27867B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75C9E697-F3D8-438A-9C31-802DF27867B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75C9E697-F3D8-438A-9C31-802DF27867B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75C9E697-F3D8-438A-9C31-802DF27867B2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.Unity.Analyzers.Mpack/AddinInfo.cs
+++ b/src/Microsoft.Unity.Analyzers.Mpack/AddinInfo.cs
@@ -14,3 +14,5 @@ using Mono.Addins.Description;
 [assembly: AddinDependency("MonoDevelop.Core", MonoDevelop.BuildInfo.Version)]
 [assembly: AddinDependency("MonoDevelop.Ide", MonoDevelop.BuildInfo.Version)]
 [assembly: AddinDependency("MonoDevelop.CSharpBinding", MonoDevelop.BuildInfo.Version)]
+[assembly: AddinDependency("MonoDevelop.Refactoring", MonoDevelop.BuildInfo.Version)]
+[assembly: AddinDependency("MonoDevelop.TextEditor", MonoDevelop.BuildInfo.Version)]

--- a/src/Microsoft.Unity.Analyzers.Mpack/AddinInfo.cs
+++ b/src/Microsoft.Unity.Analyzers.Mpack/AddinInfo.cs
@@ -1,0 +1,16 @@
+﻿using Mono.Addins;
+using Mono.Addins.Description;
+
+[assembly: Addin(
+	"Microsoft.Unity.Analyzers",
+	Category = "Game Development"
+)]
+
+[assembly: AddinName("Microsoft.Unity.Analyzers")]
+[assembly: AddinCategory("IDE extensions")]
+[assembly: AddinDescription("Roslyn Analyzers for Unity developers")]
+[assembly: AddinAuthor("Microsoft Corporation")]
+
+[assembly: AddinDependency("MonoDevelop.Core", MonoDevelop.BuildInfo.Version)]
+[assembly: AddinDependency("MonoDevelop.Ide", MonoDevelop.BuildInfo.Version)]
+[assembly: AddinDependency("MonoDevelop.CSharpBinding", MonoDevelop.BuildInfo.Version)]

--- a/src/Microsoft.Unity.Analyzers.Mpack/Manifest.addin.xml
+++ b/src/Microsoft.Unity.Analyzers.Mpack/Manifest.addin.xml
@@ -1,16 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ExtensionModel>
-
-	<Extension path="/MonoDevelop/Refactoring/AnalyzerAssemblies">
-		<Assembly file="Microsoft.Unity.Analyzers.dll" />
-	</Extension>
 	
   <Extension path="/MonoDevelop/Ide/Composition">
     <Assembly file="Microsoft.Unity.Analyzers.dll" />
   </Extension>
- 
-  <Runtime>
-    <Import assembly="Microsoft.Unity.Analyzers.dll" />
-  </Runtime>>
   
 </ExtensionModel>

--- a/src/Microsoft.Unity.Analyzers.Mpack/Manifest.addin.xml
+++ b/src/Microsoft.Unity.Analyzers.Mpack/Manifest.addin.xml
@@ -2,11 +2,11 @@
 <ExtensionModel>
 
 	<Extension path="/MonoDevelop/Refactoring/AnalyzerAssemblies">
-		<Assembly file="Microsoft.Unity.Analyzers" />
+		<Assembly file="Microsoft.Unity.Analyzers.dll" />
 	</Extension>
 	
   <Extension path="/MonoDevelop/Ide/Composition">
-    <Assembly file="Microsoft.Unity.Analyzers" />
+    <Assembly file="Microsoft.Unity.Analyzers.dll" />
   </Extension>
  
   <Runtime>

--- a/src/Microsoft.Unity.Analyzers.Mpack/Manifest.addin.xml
+++ b/src/Microsoft.Unity.Analyzers.Mpack/Manifest.addin.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ExtensionModel>
+
+	<Extension path="/MonoDevelop/Refactoring/AnalyzerAssemblies">
+		<Assembly file="Microsoft.Unity.Analyzers" />
+	</Extension>
+	
+  <Extension path="/MonoDevelop/Ide/Composition">
+    <Assembly file="Microsoft.Unity.Analyzers" />
+  </Extension>
+ 
+  <Runtime>
+    <Import assembly="Microsoft.Unity.Analyzers.dll" />
+  </Runtime>>
+  
+</ExtensionModel>

--- a/src/Microsoft.Unity.Analyzers.Mpack/Microsoft.Unity.Analyzers.Mpack.csproj
+++ b/src/Microsoft.Unity.Analyzers.Mpack/Microsoft.Unity.Analyzers.Mpack.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <EnableDefaultEmbeddedResourceItems>False</EnableDefaultEmbeddedResourceItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MonoDevelop.Addins" Version="0.4.7" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0" PrivateAssets="all">
+</PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Manifest.addin.xml">
+      <LogicalName>Manifest.addin.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Unity.Analyzers\Microsoft.Unity.Analyzers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Unity.Analyzers.Mpack/Microsoft.Unity.Analyzers.Mpack.csproj
+++ b/src/Microsoft.Unity.Analyzers.Mpack/Microsoft.Unity.Analyzers.Mpack.csproj
@@ -2,19 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <EnableDefaultEmbeddedResourceItems>False</EnableDefaultEmbeddedResourceItems>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="MonoDevelop.Addins" Version="0.4.7" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0" PrivateAssets="all">
-</PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="Manifest.addin.xml">
-      <LogicalName>Manifest.addin.xml</LogicalName>
-    </EmbeddedResource>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Unity.Analyzers.Vsix.sln
+++ b/src/Microsoft.Unity.Analyzers.Vsix.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29102.190
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Unity.Analyzers.Vsix", "Microsoft.Unity.Analyzers.Vsix\Microsoft.Unity.Analyzers.Vsix.csproj", "{537C1741-941F-489E-80BC-E06D081D86F3}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Unity.Analyzers", "Microsoft.Unity.Analyzers\Microsoft.Unity.Analyzers.csproj", "{3352E64B-4789-46A3-A589-BDA698379164}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Unity.Analyzers.Tests", "Microsoft.Unity.Analyzers.Tests\Microsoft.Unity.Analyzers.Tests.csproj", "{253C9CCC-B9BD-4137-AC93-E73EF7E4AAA7}"
@@ -23,6 +25,10 @@ Global
 		{253C9CCC-B9BD-4137-AC93-E73EF7E4AAA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{253C9CCC-B9BD-4137-AC93-E73EF7E4AAA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{253C9CCC-B9BD-4137-AC93-E73EF7E4AAA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{537C1741-941F-489E-80BC-E06D081D86F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{537C1741-941F-489E-80BC-E06D081D86F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{537C1741-941F-489E-80BC-E06D081D86F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{537C1741-941F-489E-80BC-E06D081D86F3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{671EB45F-5783-41EF-831C-25EED97670C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{671EB45F-5783-41EF-831C-25EED97670C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{671EB45F-5783-41EF-831C-25EED97670C0}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/Microsoft.Unity.Analyzers.sln
+++ b/src/Microsoft.Unity.Analyzers.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Unity.Analyzers.V
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "new-analyzer", "new-analyzer\new-analyzer.csproj", "{671EB45F-5783-41EF-831C-25EED97670C0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Unity.Analyzers.Mpack", "Microsoft.Unity.Analyzers.Mpack\Microsoft.Unity.Analyzers.Mpack.csproj", "{75C9E697-F3D8-438A-9C31-802DF27867B2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{671EB45F-5783-41EF-831C-25EED97670C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{671EB45F-5783-41EF-831C-25EED97670C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{671EB45F-5783-41EF-831C-25EED97670C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75C9E697-F3D8-438A-9C31-802DF27867B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75C9E697-F3D8-438A-9C31-802DF27867B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75C9E697-F3D8-438A-9C31-802DF27867B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75C9E697-F3D8-438A-9C31-802DF27867B2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixes #20.

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change;

This adds an mpack project to the solution. On Visual Studio for Mac, make this project the startup project and click run to launch an experimental instance of Visual Studio for Mac where the Unity analyzers will be loaded to debug them.

<img width="1219" alt="Screen Shot 2020-02-11 at 4 24 24 PM" src="https://user-images.githubusercontent.com/79284/74291868-26c9b400-4ceb-11ea-868c-3f81c694d552.png">
