### PR TITLE
ImproperSerializeField analyzer

### DIFF
--- a/doc/UNT0013.md
+++ b/doc/UNT0013.md
@@ -1,0 +1,43 @@
+# UNT0012 Unused Coroutine Return Value
+
+The SerializeField attribute is redundant for public fields, and invalid for properties. Unlike SerializeReference, the compiler allows you to use the SerializeField attribute on properties, even if it is invalid and will not function in the Unity editor.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using System.Collections;
+using UnityEngine;
+
+public class SerializedAttributes : MonoBehaviour
+{
+    [SerializeField] // correct usage
+    private string privateField;
+    
+    [SerializeField] // redundant usage
+    public string publicField;
+
+    [SerializeField] // invalid usage
+    private string PrivateProperty { get; set; }
+}
+```
+
+## Solution
+
+Remove the SerializeField attribute when it is redundant or invalid:
+
+```csharp
+using System.Collections;
+using UnityEngine;
+
+public class SerializedAttributes : MonoBehaviour
+{
+    [SerializeField] // correct usage
+    private string privateField;
+    
+    public string publicField;
+
+    private string PrivateProperty { get; set; }
+}
+```
+
+A code fix is offered for this diagnostic to automatically apply this change.

--- a/doc/index.md
+++ b/doc/index.md
@@ -14,6 +14,7 @@ ID | Title | Category
 [UNT0010](UNT0010.md) | MonoBehaviour instance creation | Type Safety
 [UNT0011](UNT0011.md) | ScriptableObject instance creation | Type Safety
 [UNT0012](UNT0012.md) | Unused coroutine return value | Correctness
+[UNT0013](UNT0013.md) | Invalid or redundant SerializeField attribute | Correctness
 
 # Diagnostic Suppressors
 

--- a/src/Microsoft.Unity.Analyzers.Tests/ImproperSerializeFieldTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ImproperSerializeFieldTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Unity.Analyzers.Tests
 	public class ImproperSerializeFieldTests
 	{
 		[Fact]
-		public async Task ValidSerializeFieldTest ()
+		public async Task ValidSerializeFieldTest()
 		{
 			const string test = @"
 using UnityEngine;
@@ -24,7 +24,7 @@ class Camera : MonoBehaviour
 		}
 
 		[Fact]
-		public async Task RedundantSerializeFieldTest ()
+		public async Task RedundantSerializeFieldTest()
 		{
 			const string test = @"
 using UnityEngine;
@@ -71,6 +71,49 @@ using UnityEngine;
 class Camera : MonoBehaviour
 {
     private string privateProperty { get; set; } 
+}
+";
+
+			await Verify.VerifyCodeFixAsync(test, diagnostic, fixedTest);
+		}
+
+		[Fact]
+		public async Task ValidSerializeMultipleFieldsTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    [SerializeField]
+    private string privateField1, privateField2, privateField3;
+}
+";
+
+			await Verify.VerifyAnalyzerAsync(test);
+		}
+
+		[Fact]
+		public async Task RedundantSerializeMultipleFieldsTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    [SerializeField]
+    public string publicField1, publicField2, publicField3;
+}
+";
+
+			var diagnostic = Verify.Diagnostic(ImproperSerializeFieldAnalyzer.Id).WithLocation(6, 5).WithArguments("publicField1, publicField2, publicField3");
+
+			const string fixedTest = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public string publicField1, publicField2, publicField3;
 }
 ";
 

--- a/src/Microsoft.Unity.Analyzers.Tests/ImproperSerializeFieldTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ImproperSerializeFieldTests.cs
@@ -8,25 +8,72 @@ namespace Microsoft.Unity.Analyzers.Tests
 	public class ImproperSerializeFieldTests
 	{
 		[Fact]
-		public async Task Test ()
+		public async Task ValidSerializeFieldTest ()
 		{
 			const string test = @"
 using UnityEngine;
 
 class Camera : MonoBehaviour
 {
+    [SerializeField]
+    private string privateField;
 }
 ";
 
-			var diagnostic = Verify.Diagnostic();
+			await Verify.VerifyAnalyzerAsync(test);
+		}
+
+		[Fact]
+		public async Task RedundantSerializeFieldTest ()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    [SerializeField]
+    public string publicField;
+}
+";
+
+			var diagnostic = Verify.Diagnostic(ImproperSerializeFieldAnalyzer.Id).WithLocation(6, 5).WithArguments("publicField");
 
 			const string fixedTest = @"
 using UnityEngine;
 
 class Camera : MonoBehaviour
 {
+    public string publicField;
 }
 ";
+
+			await Verify.VerifyCodeFixAsync(test, diagnostic, fixedTest);
+		}
+
+		[Fact]
+		public async Task InvalidSerializeFieldTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    [SerializeField]
+    private string privateProperty { get; set; } 
+}
+";
+
+			var diagnostic = Verify.Diagnostic(ImproperSerializeFieldAnalyzer.Id).WithLocation(6, 5).WithArguments("privateProperty");
+
+			const string fixedTest = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private string privateProperty { get; set; } 
+}
+";
+
 			await Verify.VerifyCodeFixAsync(test, diagnostic, fixedTest);
 		}
 	}

--- a/src/Microsoft.Unity.Analyzers.Tests/ImproperSerializeFieldTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ImproperSerializeFieldTests.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests
+{
+	using Verify = UnityCodeFixVerifier<ImproperSerializeFieldAnalyzer, ImproperSerializeFieldCodeFix>;
+
+	public class ImproperSerializeFieldTests
+	{
+		[Fact]
+		public async Task Test ()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+}
+";
+
+			var diagnostic = Verify.Diagnostic();
+
+			const string fixedTest = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+}
+";
+			await Verify.VerifyCodeFixAsync(test, diagnostic, fixedTest);
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers.Tests/ImproperSerializeFieldTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ImproperSerializeFieldTests.cs
@@ -82,6 +82,7 @@ class Camera : MonoBehaviour
 		{
 			const string test = @"
 using UnityEngine;
+using UnityEngine.Serialization;
 
 class Camera : MonoBehaviour
 {
@@ -98,6 +99,7 @@ class Camera : MonoBehaviour
 		{
 			const string test = @"
 using UnityEngine;
+using UnityEngine.Serialization;
 
 class Camera : MonoBehaviour
 {
@@ -106,14 +108,112 @@ class Camera : MonoBehaviour
 }
 ";
 
-			var diagnostic = Verify.Diagnostic(ImproperSerializeFieldAnalyzer.Id).WithLocation(6, 5).WithArguments("publicField1, publicField2, publicField3");
+			var diagnostic = Verify.Diagnostic(ImproperSerializeFieldAnalyzer.Id).WithLocation(7, 5).WithArguments("publicField1, publicField2, publicField3");
 
 			const string fixedTest = @"
 using UnityEngine;
+using UnityEngine.Serialization;
 
 class Camera : MonoBehaviour
 {
     public string publicField1, publicField2, publicField3;
+}
+";
+
+			await Verify.VerifyCodeFixAsync(test, diagnostic, fixedTest);
+		}
+
+		[Fact]
+		public async Task ValidSerializeFieldMultipleAttributesTest()
+		{
+			const string test = @"
+using UnityEngine;
+using UnityEngine.Serialization;
+
+class Camera : MonoBehaviour
+{
+    [SerializeField]
+    [FormerlySerializedAs(""somethingElse"")]
+    private string privateField;
+}
+";
+
+			await Verify.VerifyAnalyzerAsync(test);
+		}
+
+		[Fact]
+		public async Task RedundantSerializeFieldMultipleAttributeTest()
+		{
+			const string test = @"
+using UnityEngine;
+using UnityEngine.Serialization;
+
+class Camera : MonoBehaviour
+{
+    [SerializeField]
+    [FormerlySerializedAs(""somethingElse"")]
+    public string publicField;
+}
+";
+
+			var diagnostic = Verify.Diagnostic(ImproperSerializeFieldAnalyzer.Id).WithLocation(7, 5).WithArguments("publicField");
+
+			const string fixedTest = @"
+using UnityEngine;
+using UnityEngine.Serialization;
+
+class Camera : MonoBehaviour
+{
+    [FormerlySerializedAs(""somethingElse"")]
+    public string publicField;
+}
+";
+
+
+			await Verify.VerifyCodeFixAsync(test, diagnostic, fixedTest);
+		}
+
+		[Fact]
+		public async Task ValidSerializeFieldMultipleAttributeInlineTest()
+		{
+			const string test = @"
+using UnityEngine;
+using UnityEngine.Serialization;
+
+class Camera : MonoBehaviour
+{
+    [SerializeField, FormerlySerializedAs(""somethingElse"")]
+    private string privateField;
+}
+";
+
+			await Verify.VerifyAnalyzerAsync(test);
+		}
+
+		[Fact]
+		public async Task RedundantSerializeFieldMultipleAttributeInlineTest()
+		{
+			const string test = @"
+using UnityEngine;
+using UnityEngine.Serialization;
+
+class Camera : MonoBehaviour
+{
+    [SerializeField, FormerlySerializedAs(""somethingElse"")]
+    public string publicField;
+}
+";
+
+			var diagnostic = Verify.Diagnostic(ImproperSerializeFieldAnalyzer.Id).WithLocation(7, 5).WithArguments("publicField");
+
+			const string fixedTest = @"
+using UnityEngine;
+using UnityEngine.Serialization;
+
+class Camera : MonoBehaviour
+{
+    [FormerlySerializedAs(""somethingElse"")]
+    public string publicField;
 }
 ";
 

--- a/src/Microsoft.Unity.Analyzers/ImproperSerializeField.cs
+++ b/src/Microsoft.Unity.Analyzers/ImproperSerializeField.cs
@@ -1,0 +1,127 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Unity.Analyzers.Resources;
+
+namespace Microsoft.Unity.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class ImproperSerializeFieldAnalyzer : DiagnosticAnalyzer
+	{
+		public const string Id = "UNT0013";
+
+		private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			Id,
+			title: Strings.ImproperSerializeFieldDiagnosticTitle,
+			messageFormat: Strings.ImproperSerializeFieldDiagnosticMessageFormat,
+			category: DiagnosticCategory.Correctness,
+			defaultSeverity: DiagnosticSeverity.Info,
+			isEnabledByDefault: true,
+			description: Strings.ImproperSerializeFieldDiagnosticDescription);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.RegisterSyntaxNodeAction(AnalyzeDeclaration, SyntaxKind.PropertyDeclaration);
+			context.RegisterSyntaxNodeAction(AnalyzeDeclaration, SyntaxKind.FieldDeclaration);
+		}
+
+		private static void AnalyzeDeclaration(SyntaxNodeAnalysisContext context)
+		{
+			var member = (MemberDeclarationSyntax)context.Node;
+			if (!(member is PropertyDeclarationSyntax || member is FieldDeclarationSyntax))
+				return;
+
+			var symbol = context.SemanticModel.GetSymbolInfo(member);
+			if (symbol.Symbol != null)
+				return;
+
+			if (!HasInvalidSerializeFieldAttribute(symbol.Symbol, out var memberName))
+				return;
+
+			context.ReportDiagnostic(Diagnostic.Create(Rule, member.GetLocation(), memberName));
+		}
+
+		private static bool HasInvalidSerializeFieldAttribute(ISymbol symbol, out string memberName)
+		{
+			memberName = null;
+			if (!(symbol is IPropertySymbol || (symbol is IFieldSymbol && symbol.DeclaredAccessibility == Accessibility.Public)))
+				return false;
+
+			var containingType = symbol.ContainingType;
+			if (!containingType.Extends(typeof(UnityEngine.Object)))
+				return false;
+
+			var hasSerializeFieldAttribute = symbol
+				.GetAttributes()
+				.Any(a => a.AttributeClass.Matches(typeof(UnityEngine.SerializeField)));
+
+			if (!hasSerializeFieldAttribute)
+				return false;
+
+			memberName = symbol.Name;
+			return true;
+		}
+	}
+
+	[ExportCodeFixProvider(LanguageNames.CSharp)]
+	public class ImproperSerializeFieldCodeFix : CodeFixProvider
+	{
+		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ImproperSerializeFieldAnalyzer.Id);
+
+		public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+			var declaration = root.FindNode(context.Span) as MemberDeclarationSyntax;
+			if (declaration == null)
+				return;
+
+			if (!(declaration is PropertyDeclarationSyntax || declaration is FieldDeclarationSyntax))
+				return;
+
+			context.RegisterCodeFix(
+				CodeAction.Create(
+					Strings.ImproperSerializeFieldCodeFixTitle,
+					ct => RemoveSerializeFieldAttribute(context.Document, declaration, ct),
+					declaration.ToFullString()),
+				context.Diagnostics);
+		}
+
+		private static async Task<Document> RemoveSerializeFieldAttribute(Document document, MemberDeclarationSyntax declaration, CancellationToken cancellationToken)
+		{
+			var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+			var attributes = new SyntaxList<AttributeListSyntax>();
+
+			foreach (var attributeList in declaration.AttributeLists)
+			{
+				var nodes = attributeList
+					.Attributes
+					.Where(a => a.Name.ToString() == "SerializeField");
+
+				if (nodes.Count() > 0)
+				{
+					var newAttributes = attributeList.RemoveNodes(nodes, SyntaxRemoveOptions.KeepNoTrivia);
+					attributes.Add(newAttributes);
+				}
+			}
+
+			var newDeclaration = declaration.WithAttributeLists(attributes);
+			var newRoot = root.ReplaceNode(declaration, newDeclaration);
+			return document.WithSyntaxRoot(newRoot);
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/ImproperSerializeField.cs
+++ b/src/Microsoft.Unity.Analyzers/ImproperSerializeField.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Unity.Analyzers
 			bool foundMatchingSymbol = false;
 			foreach (var symbol in symbols)
 			{
-				if (!(symbol is IFieldSymbol))
+				if (!(symbol is IFieldSymbol && symbol.DeclaredAccessibility == Accessibility.Public))
 					continue;
 
 				var containingType = symbol.ContainingType;

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -232,6 +232,42 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to TODO: Add code fix title.
+        /// </summary>
+        internal static string ImproperSerializeFieldCodeFixTitle {
+            get {
+                return ResourceManager.GetString("ImproperSerializeFieldCodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TODO: Add description..
+        /// </summary>
+        internal static string ImproperSerializeFieldDiagnosticDescription {
+            get {
+                return ResourceManager.GetString("ImproperSerializeFieldDiagnosticDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TODO: Add Message format.
+        /// </summary>
+        internal static string ImproperSerializeFieldDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("ImproperSerializeFieldDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TODO: Add title.
+        /// </summary>
+        internal static string ImproperSerializeFieldDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("ImproperSerializeFieldDiagnosticTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add static constructor.
         /// </summary>
         internal static string InitializeOnLoadStaticCtorCodeFixTitle {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to TODO: Add code fix title.
+        ///   Looks up a localized string similar to Remove SerializeField attribute.
         /// </summary>
         internal static string ImproperSerializeFieldCodeFixTitle {
             get {
@@ -241,7 +241,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to TODO: Add description..
+        ///   Looks up a localized string similar to SerializeField attribute does not work on properties, and are unnecessary for public fields.
         /// </summary>
         internal static string ImproperSerializeFieldDiagnosticDescription {
             get {
@@ -250,7 +250,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to TODO: Add Message format.
+        ///   Looks up a localized string similar to SerializeField attribute is invalid or redundant here.
         /// </summary>
         internal static string ImproperSerializeFieldDiagnosticMessageFormat {
             get {
@@ -259,7 +259,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to TODO: Add title.
+        ///   Looks up a localized string similar to Remove invalid SerializeField attribute.
         /// </summary>
         internal static string ImproperSerializeFieldDiagnosticTitle {
             get {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SerializeField attribute is invalid or redundant here.
+        ///   Looks up a localized string similar to SerializeField attribute is invalid or redundant for property or field(s): {0}.
         /// </summary>
         internal static string ImproperSerializeFieldDiagnosticMessageFormat {
             get {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -291,4 +291,16 @@
   <data name="UnusedCoroutineReturnValueDiagnosticTitle" xml:space="preserve">
     <value>Unused Unity Coroutine</value>
   </data>
+  <data name="ImproperSerializeFieldCodeFixTitle" xml:space="preserve">
+    <value>TODO: Add code fix title</value>
+  </data>
+  <data name="ImproperSerializeFieldDiagnosticDescription" xml:space="preserve">
+    <value>TODO: Add description.</value>
+  </data>
+  <data name="ImproperSerializeFieldDiagnosticMessageFormat" xml:space="preserve">
+    <value>TODO: Add Message format</value>
+  </data>
+  <data name="ImproperSerializeFieldDiagnosticTitle" xml:space="preserve">
+    <value>TODO: Add title</value>
+  </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -298,7 +298,8 @@
     <value>SerializeField attribute does not work on properties, and are unnecessary for public fields</value>
   </data>
   <data name="ImproperSerializeFieldDiagnosticMessageFormat" xml:space="preserve">
-    <value>SerializeField attribute is invalid or redundant here</value>
+    <value>SerializeField attribute is invalid or redundant for property or field(s): {0}</value>
+    <comment>{0} is a list of identifiers declared with a SerializeField attribute</comment>
   </data>
   <data name="ImproperSerializeFieldDiagnosticTitle" xml:space="preserve">
     <value>Remove invalid SerializeField attribute</value>

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -292,15 +292,15 @@
     <value>Unused Unity Coroutine</value>
   </data>
   <data name="ImproperSerializeFieldCodeFixTitle" xml:space="preserve">
-    <value>TODO: Add code fix title</value>
+    <value>Remove SerializeField attribute</value>
   </data>
   <data name="ImproperSerializeFieldDiagnosticDescription" xml:space="preserve">
-    <value>TODO: Add description.</value>
+    <value>SerializeField attribute does not work on properties, and are unnecessary for public fields</value>
   </data>
   <data name="ImproperSerializeFieldDiagnosticMessageFormat" xml:space="preserve">
-    <value>TODO: Add Message format</value>
+    <value>SerializeField attribute is invalid or redundant here</value>
   </data>
   <data name="ImproperSerializeFieldDiagnosticTitle" xml:space="preserve">
-    <value>TODO: Add title</value>
+    <value>Remove invalid SerializeField attribute</value>
   </data>
 </root>


### PR DESCRIPTION
Fixes #14

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:

This PR adds an analyzer that warns about improper uses of the `SerializeField` attribute. It also provides a code fix suggestion to automatically remove improper uses of the attribute from the code.

#### Notes

I'm not sure if my solution for checking fields is correct. Field declarations can include multiple symbols. In this case, I iterate through the symbols, and any that meet the requirements results in the warning and code fix suggestion. Could use another set of eyes on it - does this look correct to you?