### PR TITLE
Do not report UNT0001 on methods with modifiers

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/EmptyUnityMessageTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/EmptyUnityMessageTests.cs
@@ -66,5 +66,65 @@ class Camera : MonoBehaviour
 ";
 			await Verify.VerifyAnalyzerAsync(test);
 		}
+
+		[Fact]
+		public async Task VirtualFixedUpdate()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public virtual void FixedUpdate()
+    {
+    }
+}
+";
+			await Verify.VerifyAnalyzerAsync(test);
+		}
+
+		[Fact]
+		public async Task VirtualOverrideFixedUpdate()
+		{
+			const string test = @"
+using UnityEngine;
+
+class BaseBehaviour : MonoBehaviour
+{
+	public virtual void FixedUpdate()
+	{
+	}
+}
+
+class Camera : BaseBehaviour
+{
+    public override void FixedUpdate()
+    {
+    }
+}
+";
+			await Verify.VerifyAnalyzerAsync(test);
+		}
+
+		[Fact]
+		public async Task AbstractOverrideFixedUpdate()
+		{
+			const string test = @"
+using UnityEngine;
+
+abstract class BaseBehaviour : MonoBehaviour
+{
+	public abstract void FixedUpdate();
+}
+
+class Camera : BaseBehaviour
+{
+    public override void FixedUpdate()
+    {
+    }
+}
+";
+			await Verify.VerifyAnalyzerAsync(test);
+		}
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/EmptyUnityMessage.cs
+++ b/src/Microsoft.Unity.Analyzers/EmptyUnityMessage.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Unity.Analyzers
 			if (method?.Body == null)
 				return;
 
-			if (method.Modifiers.Any(SyntaxKind.AbstractKeyword) || method.Modifiers.Any(SyntaxKind.VirtualKeyword))
+			if (HasPolymorphicModifier(method))
 				return;
 
 			if (method.Body.Statements.Count > 0)
@@ -65,6 +65,22 @@ namespace Microsoft.Unity.Analyzers
 				return;
 
 			context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation(), symbol.Name));
+		}
+
+		private static bool HasPolymorphicModifier(MethodDeclarationSyntax method)
+		{
+			foreach (var modifier in method.Modifiers)
+			{
+				switch (modifier.Kind())
+				{
+					case SyntaxKind.AbstractKeyword:
+					case SyntaxKind.VirtualKeyword:
+					case SyntaxKind.OverrideKeyword:
+						return true;
+				}
+			}
+
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Fixes #25 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;

#### Short description of what this resolves:
Polymorphic modifiers like virtual, override or abstract added by users give those methods another semantic that we can't discover, we should not provide a diagnostic here.
