### PR TITLE
Adopt the same Unity logic for Unity message detection

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/MessageSignatureTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/MessageSignatureTests.cs
@@ -42,6 +42,84 @@ class Camera : MonoBehaviour
 		}
 
 		[Fact]
+		public async Task MessageSignatureUnityLogic()
+		{
+			// Unity allows to specify less parameters if you don't need them
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private void OnAnimatorIK()
+    {
+    }
+}
+";
+
+			await Verify.VerifyAnalyzerAsync(test);
+		}
+
+		[Fact]
+		public async Task MessageSignatureUnityLogicBadType()
+		{
+			// But we enforce proper type
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private void OnAnimatorIK(string bad)
+    {
+    }
+}
+";
+
+			var diagnostic = Verify.Diagnostic().WithLocation(6, 18).WithArguments("OnAnimatorIK");
+
+			const string fixedTest = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private void OnAnimatorIK(int layerIndex)
+    {
+    }
+}
+";
+			await Verify.VerifyCodeFixAsync(test, diagnostic, fixedTest);
+		}
+
+		[Fact]
+		public async Task MessageSignatureUnityLogicExtraParameters()
+		{
+			// And we prevent extra parameters
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private void OnAnimatorIK(int layerIndex, int extra)
+    {
+    }
+}
+";
+
+			var diagnostic = Verify.Diagnostic().WithLocation(6, 18).WithArguments("OnAnimatorIK");
+
+			const string fixedTest = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private void OnAnimatorIK(int layerIndex)
+    {
+    }
+}
+";
+			await Verify.VerifyCodeFixAsync(test, diagnostic, fixedTest);
+		}
+
+		[Fact]
 		public async Task MessageSignatureWithInheritance()
 		{
 			// two declarations for OnDestroy (one in EditorWindow and one in ScriptableObject) 

--- a/src/Microsoft.Unity.Analyzers/ScriptInfo.cs
+++ b/src/Microsoft.Unity.Analyzers/ScriptInfo.cs
@@ -93,10 +93,10 @@ namespace Microsoft.Unity.Analyzers
 				return false;
 
 			var parameters = method.GetParameters();
-			if (parameters.Length != symbol.Parameters.Length)
+			if (parameters.Length < symbol.Parameters.Length)
 				return false;
 
-			for (var i = 0; i < parameters.Length; i++)
+			for (var i = 0; i < symbol.Parameters.Length; i++)
 			{
 				if (!symbol.Parameters[i].Type.Matches(parameters[i].ParameterType))
 					return false;


### PR DESCRIPTION
Fixes #27 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [x] I have added tests that prove my fix is effective or that my feature works ;

#### Short description of what this resolves:
Unity is able to call Unity messages by Reflection, even if not all parameters are provided. For example you can use `OnAnimatorIK()` or `OnAnimatorIK(int layerIndex)` in your code, and both of those methods work perfectly fine. 

#### Changes proposed in this pull request:
- Update the ScriptInfo class to adopt the same logic for detection of valid Unity messages. 
- Add extra tests for `UNT0006`
