### PR TITLE
Retire UNT0005

### DIFF
--- a/doc/UNT0005.md
+++ b/doc/UNT0005.md
@@ -1,5 +1,11 @@
 # UNT0005 Time.deltaTime used with FixedUpdate
 
+**This rule is now disabled by default**, see why [here](https://github.com/microsoft/Microsoft.Unity.Analyzers/issues/26). if you still want to use it, you can add the following to your `.editorconfig` file:
+```editorconfig
+[*.cs]
+dotnet_diagnostic.UNT0005.severity = suggestion
+```
+
 FixedUpdate is independent of the frame rate. Use Time.fixedDeltaTime instead of Time.deltaTime.
 
 ## Examples of patterns that are flagged by this analyzer

--- a/doc/index.md
+++ b/doc/index.md
@@ -6,7 +6,7 @@ ID | Title | Category
 [UNT0002](UNT0002.md) | Inefficient tag comparison | Performance
 [UNT0003](UNT0003.md) | Usage of non generic GetComponent | Type Safety
 [UNT0004](UNT0004.md) | Time.fixedDeltaTime used with Update | Correctness
-[UNT0005](UNT0005.md) | Time.deltaTime used with FixedUpdate | Correctness
+[UNT0005](UNT0005.md) | Time.deltaTime used with FixedUpdate `[retired]` | Correctness
 [UNT0006](UNT0006.md) | Incorrect message signature | Type Safety
 [UNT0007](UNT0007.md) | Null coalescing on Unity objects | Correctness
 [UNT0008](UNT0008.md) | Null propagation on Unity objects | Correctness

--- a/src/Microsoft.Unity.Analyzers.Tests/UpdateDeltaTimeTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UpdateDeltaTimeTests.cs
@@ -23,8 +23,14 @@ class Camera : MonoBehaviour
      }
 }
 ";
+			// see https://github.com/microsoft/Microsoft.Unity.Analyzers/issues/26
+			// this rule is now disabled by default
+			VerifyCSharpDiagnostic(test);
 
-			var diagnostic = ExpectDiagnostic(UpdateDeltaTimeAnalyzer.FixedUpdateId)
+			// but can be re-enabled using ruleset or editorconfig:
+			// dotnet_diagnostic.UNT0005.severity = suggestion
+			
+			/*var diagnostic = ExpectDiagnostic(UpdateDeltaTimeAnalyzer.FixedUpdateId)
 				.WithLocation(8, 25);
 
 			VerifyCSharpDiagnostic(test, diagnostic);
@@ -40,7 +46,7 @@ class Camera : MonoBehaviour
      }
 }
 ";
-			VerifyCSharpFix(test, fixedTest);
+			VerifyCSharpFix(test, fixedTest);*/
 		}
 
 		[Fact]

--- a/src/Microsoft.Unity.Analyzers/UpdateDeltaTime.cs
+++ b/src/Microsoft.Unity.Analyzers/UpdateDeltaTime.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Unity.Analyzers
 			messageFormat: Strings.FixedUpdateWithoutDeltaTimeDiagnosticMessageFormat,
 			category: DiagnosticCategory.Correctness,
 			defaultSeverity: DiagnosticSeverity.Info,
-			isEnabledByDefault: true,
+			isEnabledByDefault: false, // see https://github.com/microsoft/Microsoft.Unity.Analyzers/issues/26
 			description: Strings.FixedUpdateWithoutDeltaTimeDiagnosticDescription);
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(UpdateRule, FixedUpdateRule);


### PR DESCRIPTION
Fixes #26 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Retire UNT0005

#### Changes proposed in this pull request:
Set the rule descriptor `IsEnabledByDefault` to `false`, so the rule will not be active by default anymore, until explicitly enabled using an `.editorconfig` or `ruleset` file. 
