### PR TITLE
CacheExpensiveCallsAnalyzer

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/CacheExpensiveCallsTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/CacheExpensiveCallsTests.cs
@@ -15,19 +15,23 @@ namespace Microsoft.Unity.Analyzers.Tests
 			const string test = @"
 using UnityEngine;
 
-class Camera : MonoBehaviour
+class NewBehaviour : MonoBehaviour
 {
-    private void Update()
+    private Camera camera;
+
+	private void Update()
     {
-        GetComponent<Rigidbody>();
+        camera = Camera.main;
     }
 }
 ";
 
 
-			var diagnostic = ExpectDiagnostic().WithLocation(8, 9);
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(10, 18)
+				.WithArguments("Camera.main");
 
-			//VerifyCSharpDiagnostic(test, diagnostic);
+			VerifyCSharpDiagnostic(test, diagnostic);
 
 //			const string fixedTest = @"
 //using UnityEngine;

--- a/src/Microsoft.Unity.Analyzers.Tests/CacheExpensiveCallsTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/CacheExpensiveCallsTests.cs
@@ -1,0 +1,43 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests
+{
+	public class CacheExpensiveCallsTests : BaseCodeFixVerifierTest<CacheExpensiveCallsAnalyzer, CacheExpensiveCallsCodeFix>
+	{
+		[Fact]
+		public void TestTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private void Update()
+    {
+        GetComponent<Rigidbody>();
+    }
+}
+";
+
+
+			var diagnostic = ExpectDiagnostic().WithLocation(8, 9);
+
+			//VerifyCSharpDiagnostic(test, diagnostic);
+
+//			const string fixedTest = @"
+//using UnityEngine;
+
+//class Test : MonoBehaviour
+//{
+//}
+//";
+
+			//VerifyCSharpFix(test, fixedTest);
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/CacheExpensiveCalls.cs
+++ b/src/Microsoft.Unity.Analyzers/CacheExpensiveCalls.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Unity.Analyzers
 	public class CacheExpensiveCallsAnalyzer : DiagnosticAnalyzer
 	{
 		internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
-			id: "UNT0014",
+			id: "UNT0015",
 			title: Strings.CacheExpensiveCallsAnalyzerDiagnosticTitle,
 			messageFormat: Strings.CacheExpensiveCallsAnalyzerDiagnosticMessageFormat,
 			category: DiagnosticCategory.Performance,

--- a/src/Microsoft.Unity.Analyzers/CacheExpensiveCalls.cs
+++ b/src/Microsoft.Unity.Analyzers/CacheExpensiveCalls.cs
@@ -1,0 +1,139 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Unity.Analyzers.Resources;
+
+namespace Microsoft.Unity.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class CacheExpensiveCallsAnalyzer : DiagnosticAnalyzer
+	{
+		internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			id: "UNT0014",
+			title: Strings.CacheExpensiveCallsAnalyzerDiagnosticTitle,
+			messageFormat: Strings.CacheExpensiveCallsAnalyzerDiagnosticMessageFormat,
+			category: DiagnosticCategory.Performance,
+			defaultSeverity: DiagnosticSeverity.Info,
+			isEnabledByDefault: true,
+			description: Strings.CacheExpensiveCallsAnalyzerDiagnosticDescription);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		private static readonly HashSet<string> MethodNames = new HashSet<string>(new[]
+		{
+			"GetComponent",
+			"GetComponents",
+			"GetComponentInChildren",
+			"GetComponentsInChildren",
+			"GetComponentInParent",
+			"GetComponentsInParent",
+		});
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.RegisterSyntaxNodeAction(AnalyzeMethodDeclaration, SyntaxKind.MethodDeclaration);
+		}
+
+		private static void AnalyzeMethodDeclaration(SyntaxNodeAnalysisContext context)
+		{
+			if (!(context.Node is MethodDeclarationSyntax method))
+				return;
+
+			if (IsMessage(context, method, typeof(UnityEngine.MonoBehaviour), "Update") ||
+				IsMessage(context, method, typeof(UnityEngine.MonoBehaviour), "FixedUpdate"))
+			{
+				AnalyzeInvocations(context, method);
+
+				// TODO: Analyze member access in child nodes to find calls to Camera.main in Update or FixedUpdate
+				//AnalyzeMemberAccess(context, method);
+			}
+		}
+
+		private static void AnalyzeInvocations(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax method)
+		{
+			var invocations = method
+				.DescendantNodes()
+				.OfType<InvocationExpressionSyntax>();
+
+			foreach (var invocation in invocations)
+				AnalyzeInvocation(context, invocation);
+		}
+
+		private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax ies)
+		{
+			var symbol = context.SemanticModel.GetSymbolInfo(ies);
+			if (symbol.Symbol == null)
+				return;
+
+			if (!IsExpensiveCall(symbol.Symbol, out var methodName))
+				return;
+
+			context.ReportDiagnostic(Diagnostic.Create(Rule, ies.GetLocation(), methodName));
+		}
+
+		private static bool IsExpensiveCall(ISymbol symbol, out string expensiveCall)
+		{
+			expensiveCall = null;
+			if (!(symbol is IMethodSymbol method))
+				return false;
+
+			var containingType = method.ContainingType;
+			if (!containingType.Matches(typeof(UnityEngine.Component)) && !containingType.Matches(typeof(UnityEngine.GameObject)))
+				return false;
+
+			if (!MethodNames.Contains(method.Name))
+				return false;
+
+			expensiveCall = method.Name;
+			return true;
+		}
+
+		// TODO Copied from UpdateDeltaTimeAnalyzer. Make this a helper method somewhere for both
+		private static bool IsMessage(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax method, Type metadata, string methodName)
+		{
+			var classDeclaration = method?.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+			if (classDeclaration == null)
+				return false;
+
+			var methodSymbol = context.SemanticModel.GetDeclaredSymbol(method);
+
+			var typeSymbol = context.SemanticModel.GetDeclaredSymbol(classDeclaration);
+			var scriptInfo = new ScriptInfo(typeSymbol);
+			if (!scriptInfo.HasMessages)
+				return false;
+
+			if (!scriptInfo.IsMessage(methodSymbol))
+				return false;
+
+			return scriptInfo.Metadata == metadata && methodSymbol.Name == methodName;
+		}
+	}
+
+	[ExportCodeFixProvider(LanguageNames.CSharp)]
+	public class CacheExpensiveCallsCodeFix : CodeFixProvider
+	{
+		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(CacheExpensiveCallsAnalyzer.Rule.Id);
+
+		public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/MethodDeclarationSyntaxExtensions.cs
+++ b/src/Microsoft.Unity.Analyzers/MethodDeclarationSyntaxExtensions.cs
@@ -1,0 +1,37 @@
+﻿/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.Unity.Analyzers
+{
+	internal static class MethodDeclarationSyntaxExtensions
+	{
+		public static bool IsMessage(this MethodDeclarationSyntax method, SyntaxNodeAnalysisContext context, Type metadata, string methodName)
+		{
+			var classDeclaration = method?.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+			if (classDeclaration == null)
+				return false;
+
+			var methodSymbol = context.SemanticModel.GetDeclaredSymbol(method);
+
+			var typeSymbol = context.SemanticModel.GetDeclaredSymbol(classDeclaration);
+			var scriptInfo = new ScriptInfo(typeSymbol);
+			if (!scriptInfo.HasMessages)
+				return false;
+
+			if (!scriptInfo.IsMessage(methodSymbol))
+				return false;
+
+			return scriptInfo.Metadata == metadata && methodSymbol.Name == methodName;
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -61,6 +61,42 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cache expensive call in Awake.
+        /// </summary>
+        internal static string CacheExpensiveCallsAnalyzerCodeFixTitle {
+            get {
+                return ResourceManager.GetString("CacheExpensiveCallsAnalyzerCodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cache the result of expensive calls in Awake instead of calling in Update or FixedUpdate.
+        /// </summary>
+        internal static string CacheExpensiveCallsAnalyzerDiagnosticDescription {
+            get {
+                return ResourceManager.GetString("CacheExpensiveCallsAnalyzerDiagnosticDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is expensive and should not be called in Update or FixedUpdate.
+        /// </summary>
+        internal static string CacheExpensiveCallsAnalyzerDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("CacheExpensiveCallsAnalyzerDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expensive call in Update and FixedUpdate.
+        /// </summary>
+        internal static string CacheExpensiveCallsAnalyzerDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("CacheExpensiveCallsAnalyzerDiagnosticTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Correctness.
         /// </summary>
         internal static string CategoryCorrectness {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -313,4 +313,17 @@
   <data name="ImproperSerializeFieldDiagnosticTitle" xml:space="preserve">
     <value>Remove invalid SerializeField attribute</value>
   </data>
+  <data name="CacheExpensiveCallsAnalyzerCodeFixTitle" xml:space="preserve">
+    <value>Cache expensive call in Awake</value>
+  </data>
+  <data name="CacheExpensiveCallsAnalyzerDiagnosticDescription" xml:space="preserve">
+    <value>Cache the result of expensive calls in Awake instead of calling in Update or FixedUpdate</value>
+  </data>
+  <data name="CacheExpensiveCallsAnalyzerDiagnosticMessageFormat" xml:space="preserve">
+    <value>{0} is expensive and should not be called in Update or FixedUpdate</value>
+    <comment>{0} is the name of the member access or method invocation that is expensive</comment>
+  </data>
+  <data name="CacheExpensiveCallsAnalyzerDiagnosticTitle" xml:space="preserve">
+    <value>Expensive call in Update and FixedUpdate</value>
+  </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/UnityStubs.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityStubs.cs
@@ -13,6 +13,10 @@ namespace UnityEngine
 	{
 	}
 
+	class Camera
+	{
+	}
+
 	class Collision
 	{
 	}

--- a/src/Microsoft.Unity.Analyzers/UpdateDeltaTime.cs
+++ b/src/Microsoft.Unity.Analyzers/UpdateDeltaTime.cs
@@ -76,10 +76,10 @@ namespace Microsoft.Unity.Analyzers
 			if (!(context.Node is MethodDeclarationSyntax method))
 				return;
 
-			if (IsMessage(context, method, typeof(UnityEngine.MonoBehaviour), "Update"))
+			if (method.IsMessage(context, typeof(UnityEngine.MonoBehaviour), "Update"))
 				AnalyzeMemberAccess(context, method, "Time.fixedDeltaTime", UpdateRule);
 
-			if (IsMessage(context, method, typeof(UnityEngine.MonoBehaviour), "FixedUpdate"))
+			if (method.IsMessage(context, typeof(UnityEngine.MonoBehaviour), "FixedUpdate"))
 				AnalyzeMemberAccess(context, method, "Time.deltaTime", FixedUpdateRule);
 		}
 


### PR DESCRIPTION
Fixes #22

#### Checklist
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [ ] I have added tests that prove my fix is effective or that my feature works ;
- [ ] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Detects expensive calls to GetComponents and Camera.main in `Update` and `FixedUpdate` and provides a codefix to cache the results instead.

#### TODO
- [X] Detect expensive calls to GetComponent in `Update` and `FixedUpdate`
- [x] Detect expensive access to Camera.main in `Update` and `FixedUpdate`
- [x] Refactor similar code in `CacheExpensiveCalls.cs` to have one path before branching to `InvocationExpression` and `MemberAccessExpression`
- [x] Create helper class for shared code between analyzers
- [ ] Provide a code fix that caches these calls in `Awake` instead
- [ ] Ensure the code fix wont write duplicated code if the expensive call is already cached, for whatever reason. That would break user's build.
- [ ] Write tests
- [ ] Write docs
