### PR TITLE
GetComponentIncorrectTypeAnalyzer

### DIFF
--- a/doc/UNT0014.md
+++ b/doc/UNT0014.md
@@ -1,0 +1,26 @@
+# UNT0014 GetComponent called with non-Component or non-Interface Type
+
+`GetComponent`, `GetComponents`, `GetComponentInChildren`, `GetComponentsInChildren`, `GetComponentInParent`, and `GetComponentsInParent` should be called only with Types that extend `UnityEngine.Component`, or Types that are an Interface
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using System.Collections;
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private int i;
+
+    private void Start()
+    {
+        i = GetComponent<int>();
+    }
+}
+```
+
+## Solution
+
+Make sure the type argument passed to any `GetComponent` method extends `UnityEngine.Component`, or is an Interface Type.
+
+No automatic code fix is available for this diagnostic.

--- a/doc/index.md
+++ b/doc/index.md
@@ -15,6 +15,7 @@ ID | Title | Category
 [UNT0011](UNT0011.md) | ScriptableObject instance creation | Type Safety
 [UNT0012](UNT0012.md) | Unused coroutine return value | Correctness
 [UNT0013](UNT0013.md) | Invalid or redundant SerializeField attribute | Correctness
+[UNT0014](UNT0014.md) | GetComponent called with non-Component or non-Interface type | Type Safety
 
 # Diagnostic Suppressors
 

--- a/src/Microsoft.Unity.Analyzers.Tests/GetComponentIncorrectTypeTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/GetComponentIncorrectTypeTests.cs
@@ -73,5 +73,23 @@ class Camera : MonoBehaviour
 
 			VerifyCSharpDiagnostic(test, diagnostic);
 		}
+
+		[Fact]
+		public void GetComponentLegacyTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private void Start()
+    {
+        var hello = GetComponent(""Hello"");
+    }
+}
+";
+
+			VerifyCSharpDiagnostic(test);
+		}
 	}
 }

--- a/src/Microsoft.Unity.Analyzers.Tests/GetComponentIncorrectTypeTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/GetComponentIncorrectTypeTests.cs
@@ -1,0 +1,33 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests
+{
+	public class GetComponentIncorrectTypeTests : BaseDiagnosticVerifierTest<GetComponentIncorrectTypeAnalyzer>
+	{
+		[Fact]
+		public void TestTest()
+		{
+			const string test = @"
+using System.Collections;
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+	private Rigidbody rb;
+
+    private void Start()
+    {
+        GetComponent<IEnumerable>();
+    }
+}
+";
+
+			VerifyCSharpDiagnostic(test);
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers.Tests/GetComponentIncorrectTypeTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/GetComponentIncorrectTypeTests.cs
@@ -34,7 +34,6 @@ class Camera : MonoBehaviour
 		public void GetComponentCorrectTypeTest()
 		{
 			const string test = @"
-using System.Collections;
 using UnityEngine;
 
 class Camera : MonoBehaviour
@@ -55,7 +54,6 @@ class Camera : MonoBehaviour
 		public void GetComponentIncorrectTypeTest()
 		{
 			const string test = @"
-using System.Collections;
 using UnityEngine;
 
 class Camera : MonoBehaviour
@@ -70,7 +68,7 @@ class Camera : MonoBehaviour
 ";
 
 			var diagnostic = ExpectDiagnostic()
-				.WithLocation(11, 13)
+				.WithLocation(10, 13)
 				.WithArguments("Int32");
 
 			VerifyCSharpDiagnostic(test, diagnostic);

--- a/src/Microsoft.Unity.Analyzers.Tests/GetComponentIncorrectTypeTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/GetComponentIncorrectTypeTests.cs
@@ -10,7 +10,28 @@ namespace Microsoft.Unity.Analyzers.Tests
 	public class GetComponentIncorrectTypeTests : BaseDiagnosticVerifierTest<GetComponentIncorrectTypeAnalyzer>
 	{
 		[Fact]
-		public void TestTest()
+		public void GetComponentInterfaceTypeTest()
+		{
+			const string test = @"
+using System;
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private IDisposable disp;
+
+    private void Start()
+    {
+        disp = GetComponent<IDisposable>();
+    }
+}
+";
+
+			VerifyCSharpDiagnostic(test);
+		}
+
+		[Fact]
+		public void GetComponentCorrectTypeTest()
 		{
 			const string test = @"
 using System.Collections;
@@ -18,16 +39,41 @@ using UnityEngine;
 
 class Camera : MonoBehaviour
 {
-	private Rigidbody rb;
+    private Rigidbody rb;
 
     private void Start()
     {
-        GetComponent<IEnumerable>();
+        rb = GetComponent<Rigidbody>();
     }
 }
 ";
 
 			VerifyCSharpDiagnostic(test);
+		}
+
+		[Fact]
+		public void GetComponentIncorrectTypeTest()
+		{
+			const string test = @"
+using System.Collections;
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private int i;
+
+    private void Start()
+    {
+        i = GetComponent<int>();
+    }
+}
+";
+
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(11, 13)
+				.WithArguments("Int32");
+
+			VerifyCSharpDiagnostic(test, diagnostic);
 		}
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
+++ b/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
@@ -52,15 +52,15 @@ namespace Microsoft.Unity.Analyzers
 			if (symbol.Symbol == null)
 				return;
 
-			if (!IsGetComponent(symbol.Symbol, out var methodName))
+			if (!IsGetComponent(symbol.Symbol, out var identifier))
 				return;
 
-			context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), methodName));
+			context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), identifier));
 		}
 
-		private static bool IsGetComponent(ISymbol symbol, out string methodName)
+		private static bool IsGetComponent(ISymbol symbol, out string identifier)
 		{
-			methodName = null;
+			identifier = null;
 			if (!(symbol is IMethodSymbol method))
 				return false;
 
@@ -71,10 +71,11 @@ namespace Microsoft.Unity.Analyzers
 			if (!MethodNames.Contains(method.Name))
 				return false;
 
-			if (method.TypeArguments.First().Matches(typeof(UnityEngine.Component)) || method.TypeArguments.First().TypeKind == TypeKind.Interface)
+			var argumentType = method.TypeArguments.First();
+			if (argumentType.Extends(typeof(UnityEngine.Component)) || argumentType.TypeKind == TypeKind.Interface)
 				return false;
 
-			methodName = method.Name;
+			identifier = argumentType.Name;
 			return true;
 		}
 	}

--- a/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
+++ b/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Unity.Analyzers
 	public class GetComponentIncorrectTypeAnalyzer : DiagnosticAnalyzer
 	{
 		internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
-			id: "UNT0015",
+			id: "UNT0014",
 			title: Strings.GetComponentIncorrectTypeDiagnosticTitle,
 			messageFormat: Strings.GetComponentIncorrectTypeDiagnosticMessageFormat,
 			category: DiagnosticCategory.TypeSafety,

--- a/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
+++ b/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
@@ -1,0 +1,81 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Unity.Analyzers.Resources;
+
+namespace Microsoft.Unity.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class GetComponentIncorrectTypeAnalyzer : DiagnosticAnalyzer
+	{
+		internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			id: "UNT0015",
+			title: Strings.GetComponentIncorrectTypeDiagnosticTitle,
+			messageFormat: Strings.GetComponentIncorrectTypeDiagnosticMessageFormat,
+			category: DiagnosticCategory.TypeSafety,
+			defaultSeverity: DiagnosticSeverity.Info,
+			isEnabledByDefault: true,
+			description: Strings.GetComponentIncorrectTypeDiagnosticDescription);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		private static readonly HashSet<string> MethodNames = new HashSet<string>(new[]
+		{
+			"GetComponent",
+			"GetComponents",
+			"GetComponentInChildren",
+			"GetComponentsInChildren",
+			"GetComponentInParent",
+			"GetComponentsInParent",
+		});
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+		}
+
+		private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+		{
+			var invocation = (InvocationExpressionSyntax)context.Node;
+			var symbol = context.SemanticModel.GetSymbolInfo(invocation);
+			if (symbol.Symbol == null)
+				return;
+
+			if (!IsGetComponent(symbol.Symbol, out var methodName))
+				return;
+
+			context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), methodName));
+		}
+
+		private static bool IsGetComponent(ISymbol symbol, out string methodName)
+		{
+			methodName = null;
+			if (!(symbol is IMethodSymbol method))
+				return false;
+
+			var containingType = method.ContainingType;
+			if (!containingType.Matches(typeof(UnityEngine.Component)) && !containingType.Matches(typeof(UnityEngine.GameObject)))
+				return false;
+
+			if (!MethodNames.Contains(method.Name))
+				return false;
+
+			if (method.TypeArguments.First().Matches(typeof(UnityEngine.Component)) || method.TypeArguments.First().TypeKind == TypeKind.Interface)
+				return false;
+
+			methodName = method.Name;
+			return true;
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
+++ b/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
@@ -79,7 +79,10 @@ namespace Microsoft.Unity.Analyzers
 		private static bool HasInvalidTypeArgument(IMethodSymbol method, out string identifier)
 		{
 			identifier = null;
-			var argumentType = method.TypeArguments.First();
+			var argumentType = method.TypeArguments.FirstOrDefault();
+			if (argumentType == null)
+				return false;
+			
 			if (argumentType.Extends(typeof(UnityEngine.Component)) || argumentType.TypeKind == TypeKind.Interface)
 				return false;
 

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -232,6 +232,33 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to GetComponent only supports arguments that are a Unity Component or an interface type..
+        /// </summary>
+        internal static string GetComponentIncorrectTypeDiagnosticDescription {
+            get {
+                return ResourceManager.GetString("GetComponentIncorrectTypeDiagnosticDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is not a Unity Component.
+        /// </summary>
+        internal static string GetComponentIncorrectTypeDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("GetComponentIncorrectTypeDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid type for call to GetComponent.
+        /// </summary>
+        internal static string GetComponentIncorrectTypeDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("GetComponentIncorrectTypeDiagnosticTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove SerializeField attribute.
         /// </summary>
         internal static string ImproperSerializeFieldCodeFixTitle {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -313,4 +313,14 @@
   <data name="ImproperSerializeFieldDiagnosticTitle" xml:space="preserve">
     <value>Remove invalid SerializeField attribute</value>
   </data>
+  <data name="GetComponentIncorrectTypeDiagnosticDescription" xml:space="preserve">
+    <value>GetComponent only supports arguments that are a Unity Component or an interface type.</value>
+  </data>
+  <data name="GetComponentIncorrectTypeDiagnosticMessageFormat" xml:space="preserve">
+    <value>{0} is not a Unity Component</value>
+    <comment>{0} is the type passed as an argument to GetComponent</comment>
+  </data>
+  <data name="GetComponentIncorrectTypeDiagnosticTitle" xml:space="preserve">
+    <value>Invalid type for call to GetComponent</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #16

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Adds an analyzer that detects if the user is passing a type to `GetComponent` that is not a Unity Component or Interface type

#### TODO
- [X] Detect calls to GetComponent methods in the generic case where the type passed is not a Component or an Interface
- [X] ~~Do we care about the non-generic version of these calls, since we have UNT0003?~~
- [x] Write tests
- [x] Write docs
