### PR TITLE
Un-mock IDE0060

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/SuppressorVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/SuppressorVerifier.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Unity.Analyzers.Tests
 			var suppressor = (DiagnosticSuppressor)analyzer;
 
 			var analyzers = new List<DiagnosticAnalyzer>();
-			analyzers.AddRange(LoadAnalyzers("Microsoft.CodeAnalysis.Features.dll"));
-			analyzers.AddRange(LoadAnalyzers("Microsoft.CodeAnalysis.Csharp.Features.dll"));
+			analyzers.AddRange(LoadAnalyzers("Microsoft.CodeAnalysis.CodeStyle.dll"));
+			analyzers.AddRange(LoadAnalyzers("Microsoft.CodeAnalysis.CSharp.CodeStyle.dll"));
 
 			return analyzers.Where(a => a.SupportedDiagnostics
 				.Any(s => suppressor.SupportedSuppressions

--- a/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
+++ b/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-2.20164.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-2.20164.4" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -21,12 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis.CodeStyle">
-      <HintPath>$(NugetPackageRoot)microsoft.codeanalysis.csharp.codestyle\3.6.0-2.20164.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CodeStyle.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-      <HintPath>$(NugetPackageRoot)microsoft.codeanalysis.csharp.codestyle\3.6.0-2.20164.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll</HintPath>
-    </Reference>
+    <None Include="$(PkgMicrosoft_CodeAnalysis_CSharp_CodeStyle)\analyzers\dotnet\cs\*.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>  
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
+++ b/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="3.3.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-2.20164.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -18,6 +18,15 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Unity.Analyzers\Microsoft.Unity.Analyzers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeAnalysis.CodeStyle">
+      <HintPath>$(NugetPackageRoot)microsoft.codeanalysis.csharp.codestyle\3.6.0-2.20164.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CodeStyle.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
+      <HintPath>$(NugetPackageRoot)microsoft.codeanalysis.csharp.codestyle\3.6.0-2.20164.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Unity.Analyzers.Tests/UnusedMessageSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnusedMessageSuppressorTests.cs
@@ -46,7 +46,6 @@ public class TestScript : MonoBehaviour
 ";
 
 			var suppressor = ExpectSuppressor(UnusedMessageSuppressor.ParameterRule)
-				.WithSuppressedDiagnosticMock(SyntaxKind.Parameter) // Use a mock while IDE analyzers have strong dependencies on Visual Studio components
 				.WithLocation(6, 35);
 
 			VerifyCSharpDiagnostic(test, suppressor);

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -3,5 +3,6 @@
   <packageSources>
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="roslyn-analyzers" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
+    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
The IDE analyzers currently have strong dependencies on Visual Studio components, so several analyzers are not executing outside of Visual Studio. We are currently mocking them in our tests.

IDE0060 was ported to a new nuget package, so we can use it, instead of mocking it.

#### Changes proposed in this pull request:
Import the Microsoft.CodeAnalysis.CSharp.CodeStyle nuget package.

Given this package content is tagged as 'analyzer' (and all types are internal), nothing is copied to the output folder. But for our use-case, we need this copy in order to properly load the assembly in our test infrastructure.

I'm using `$(NugetPackageRoot)` to manually reference assemblies.

I tried using:
```xml
<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-2.20164.4" GeneratePathProperty="true" />`
```
and 

```xml
<ItemGroup>
  <Reference Include="Microsoft.CodeAnalysis.CodeStyle">
    <HintPath>$(PkgMicrosoft_CodeAnalysis_CSharp_CodeStyle)analyzers\dotnet\cs\Microsoft.CodeAnalysis.CodeStyle.dll</HintPath>
  </Reference>
  <Reference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
    <HintPath>$(PkgMicrosoft_CodeAnalysis_CSharp_CodeStyle)analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll</HintPath>
  </Reference>
</ItemGroup>
```

It seems to be good in the IDE, but running the build I have:

`warning MSB3245: Could not resolve this reference`






