### PR TITLE
Expose all diagnostics to the test infrastructure

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/BaseTest.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/BaseTest.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Unity.Analyzers.Tests
 	{
 
 		internal const string InterfaceTest = @"
-using UnityEngine;
-
 interface IFailure
 {
 	void FixedUpdate();

--- a/src/Microsoft.Unity.Analyzers.Tests/ContextMenuSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ContextMenuSuppressorTests.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Unity.Analyzers.Tests
 		{
 			const string test = @"
 using UnityEngine;
-using UnityEditor;
 
 class Menu : MonoBehaviour
 {
@@ -26,7 +25,7 @@ class Menu : MonoBehaviour
 }";
 
 			var suppressor = ExpectSuppressor(ContextMenuSuppressor.ContextMenuRule)
-				.WithLocation(8, 18);
+				.WithLocation(7, 18);
 
 			VerifyCSharpDiagnostic(test, suppressor);
 		}
@@ -36,7 +35,6 @@ class Menu : MonoBehaviour
 		{
 			const string test = @"
 using UnityEngine;
-using UnityEditor;
 
 class Menu : MonoBehaviour
 {
@@ -51,7 +49,7 @@ class Menu : MonoBehaviour
 
 			var suppressor = ExpectSuppressor(ContextMenuSuppressor.ContextMenuItemReadonlyRule)
 				.WithSuppressedDiagnosticMock(SyntaxKind.FieldDeclaration) // Use a mock while IDE analyzers have strong dependencies on Visual Studio components
-				.WithLocation(8, 20);
+				.WithLocation(7, 20);
 
 			VerifyCSharpDiagnostic(test, suppressor);
 		}
@@ -61,7 +59,6 @@ class Menu : MonoBehaviour
 		{
 			const string test = @"
 using UnityEngine;
-using UnityEditor;
 
 class Menu : MonoBehaviour
 {
@@ -70,7 +67,7 @@ class Menu : MonoBehaviour
 }";
 
 			var suppressor = ExpectSuppressor(ContextMenuSuppressor.ContextMenuItemUnusedRule)
-				.WithLocation(8, 20);
+				.WithLocation(7, 20);
 
 			VerifyCSharpDiagnostic(test, suppressor);
 		}
@@ -80,7 +77,6 @@ class Menu : MonoBehaviour
 		{
 			const string test = @"
 using UnityEngine;
-using UnityEditor;
 
 class Menu : MonoBehaviour
 {
@@ -94,7 +90,7 @@ class Menu : MonoBehaviour
 }";
 
 			var suppressor = ExpectSuppressor(ContextMenuSuppressor.ContextMenuRule)
-				.WithLocation(10, 18);
+				.WithLocation(9, 18);
 
 			VerifyCSharpDiagnostic(test, suppressor);
 		}

--- a/src/Microsoft.Unity.Analyzers.Tests/ImproperSerializeFieldTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ImproperSerializeFieldTests.cs
@@ -18,7 +18,7 @@ using UnityEngine;
 class Camera : MonoBehaviour
 {
     [SerializeField]
-    private string privateField;
+    private string privateField = null;
 }
 ";
 
@@ -34,7 +34,7 @@ using UnityEngine;
 class Camera : MonoBehaviour
 {
     [SerializeField]
-    public string publicField;
+    public string publicField = null;
 }
 ";
 
@@ -49,7 +49,7 @@ using UnityEngine;
 
 class Camera : MonoBehaviour
 {
-    public string publicField;
+    public string publicField = null;
 }
 ";
 
@@ -92,12 +92,16 @@ class Camera : MonoBehaviour
 		{
 			const string test = @"
 using UnityEngine;
-using UnityEngine.Serialization;
 
 class Camera : MonoBehaviour
 {
     [SerializeField]
     private string privateField1, privateField2, privateField3;
+
+    private void _ ()
+    {
+        privateField1 = privateField2 = privateField3 = privateField1;
+    }
 }
 ";
 
@@ -109,28 +113,26 @@ class Camera : MonoBehaviour
 		{
 			const string test = @"
 using UnityEngine;
-using UnityEngine.Serialization;
 
 class Camera : MonoBehaviour
 {
     [SerializeField]
-    public string publicField1, publicField2, publicField3;
+    public string publicField1 = null, publicField2 = null, publicField3 = null;
 }
 ";
 
 			var diagnostic = ExpectDiagnostic(ImproperSerializeFieldAnalyzer.Rule.Id)
-				.WithLocation(7, 5)
+				.WithLocation(6, 5)
 				.WithArguments("publicField1, publicField2, publicField3");
 
 			VerifyCSharpDiagnostic(test, diagnostic);
 
 			const string fixedTest = @"
 using UnityEngine;
-using UnityEngine.Serialization;
 
 class Camera : MonoBehaviour
 {
-    public string publicField1, publicField2, publicField3;
+    public string publicField1 = null, publicField2 = null, publicField3 = null;
 }
 ";
 
@@ -148,7 +150,7 @@ class Camera : MonoBehaviour
 {
     [SerializeField]
     [FormerlySerializedAs(""somethingElse"")]
-    private string privateField;
+    private string privateField = null;
 }
 ";
 
@@ -166,7 +168,7 @@ class Camera : MonoBehaviour
 {
     [SerializeField]
     [FormerlySerializedAs(""somethingElse"")]
-    public string publicField;
+    public string publicField = null;
 }
 ";
 
@@ -183,7 +185,7 @@ using UnityEngine.Serialization;
 class Camera : MonoBehaviour
 {
     [FormerlySerializedAs(""somethingElse"")]
-    public string publicField;
+    public string publicField = null;
 }
 ";
 
@@ -201,7 +203,7 @@ using UnityEngine.Serialization;
 class Camera : MonoBehaviour
 {
     [SerializeField, FormerlySerializedAs(""somethingElse"")]
-    private string privateField;
+    private string privateField = null;
 }
 ";
 
@@ -218,7 +220,7 @@ using UnityEngine.Serialization;
 class Camera : MonoBehaviour
 {
     [SerializeField, FormerlySerializedAs(""somethingElse"")]
-    public string publicField;
+    public string publicField = null;
 }
 ";
 
@@ -235,7 +237,7 @@ using UnityEngine.Serialization;
 class Camera : MonoBehaviour
 {
     [FormerlySerializedAs(""somethingElse"")]
-    public string publicField;
+    public string publicField = null;
 }
 ";
 

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/CodeFixVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/CodeFixVerifier.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Unity.Analyzers.Tests
 				var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, GetCompilerDiagnostics(document));
 
 				//check if applying the code fix introduced any new compiler diagnostics
-				if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any(d => d.Id != "CS1701"))
+				if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
 				{
 					// Format and get the compiler diagnostics again so that the locations make sense in the output
 					document = document.WithSyntaxRoot(Formatter.Format(document.GetSyntaxRootAsync().Result, Formatter.Annotation, document.Project.Solution.Workspace));
@@ -109,9 +109,13 @@ namespace Microsoft.Unity.Analyzers.Tests
 			}
 		}
 
-		private static ImmutableArray<Diagnostic> GetCompilerDiagnostics(Document document)
+		private static IEnumerable<Diagnostic> GetCompilerDiagnostics(Document document)
 		{
-			return document.GetSemanticModelAsync().Result.GetDiagnostics();
+			return document
+				.GetSemanticModelAsync()
+				.Result
+				.GetDiagnostics()
+				.Where(d => !NoWarn.Contains(d.Id));
 		}
 
 		private static string GetStringFromDocument(Document document)

--- a/src/Microsoft.Unity.Analyzers.Tests/SerializeFieldSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/SerializeFieldSuppressorTests.cs
@@ -21,13 +21,15 @@ class Camera : MonoBehaviour
     [SerializeField]
     private string someField;
 
-    private void _ () {
+    private void RemoveIDE0051() {
         var _ = someField;
+        RemoveIDE0051();
     }
 }
 ";
 
 			var suppressor = ExpectSuppressor(SerializeFieldSuppressor.NeverAssignedRule)
+				.WithSuppressedDiagnosticMock(SyntaxKind.FieldDeclaration) // Use a mock while IDE analyzers have strong dependencies on Visual Studio components
 				.WithLocation(7, 20);
 
 			VerifyCSharpDiagnostic(test, suppressor);
@@ -44,8 +46,9 @@ class Camera : MonoBehaviour
     [SerializeField]
     private string someField = ""default"";
 
-    private void _ () {
+    private void RemoveIDE0051() {
         var _ = someField;
+        RemoveIDE0051();
     }
 }
 ";

--- a/src/Microsoft.Unity.Analyzers.Tests/SerializeFieldSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/SerializeFieldSuppressorTests.cs
@@ -29,7 +29,6 @@ class Camera : MonoBehaviour
 ";
 
 			var suppressor = ExpectSuppressor(SerializeFieldSuppressor.NeverAssignedRule)
-				.WithSuppressedDiagnosticMock(SyntaxKind.FieldDeclaration) // Use a mock while IDE analyzers have strong dependencies on Visual Studio components
 				.WithLocation(7, 20);
 
 			VerifyCSharpDiagnostic(test, suppressor);

--- a/src/Microsoft.Unity.Analyzers.Tests/SerializeFieldSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/SerializeFieldSuppressorTests.cs
@@ -21,15 +21,13 @@ class Camera : MonoBehaviour
     [SerializeField]
     private string someField;
 
-    private void RemoveIDE0051() {
+    private void _ () {
         var _ = someField;
-        RemoveIDE0051();
     }
 }
 ";
 
 			var suppressor = ExpectSuppressor(SerializeFieldSuppressor.NeverAssignedRule)
-				.WithSuppressedDiagnosticMock(SyntaxKind.FieldDeclaration) // Use a mock while IDE analyzers have strong dependencies on Visual Studio components
 				.WithLocation(7, 20);
 
 			VerifyCSharpDiagnostic(test, suppressor);
@@ -46,9 +44,8 @@ class Camera : MonoBehaviour
     [SerializeField]
     private string someField = ""default"";
 
-    private void RemoveIDE0051() {
+    private void _ () {
         var _ = someField;
-        RemoveIDE0051();
     }
 }
 ";

--- a/src/Microsoft.Unity.Analyzers.Tests/TagComparisonTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/TagComparisonTests.cs
@@ -187,8 +187,6 @@ using UnityEngine;
 
 public class Camera : MonoBehaviour
 {
-    public Transform transform;
-
     private void Update()
     {
         Debug.Log(transform.tag == ""tag2"");
@@ -197,7 +195,7 @@ public class Camera : MonoBehaviour
 ";
 
 			var diagnostic = ExpectDiagnostic()
-				.WithLocation(10, 19);
+				.WithLocation(8, 19);
 
 			VerifyCSharpDiagnostic(test, diagnostic);
 
@@ -206,8 +204,6 @@ using UnityEngine;
 
 public class Camera : MonoBehaviour
 {
-    public Transform transform;
-
     private void Update()
     {
         Debug.Log(transform.CompareTag(""tag2""));
@@ -327,8 +323,6 @@ using UnityEngine;
 
 public class Camera : MonoBehaviour
 {
-    public Transform transform;
-
     private void Update()
     {
         Debug.Log(""tag4"" == transform.tag);
@@ -337,7 +331,7 @@ public class Camera : MonoBehaviour
 ";
 
 			var diagnostic = ExpectDiagnostic()
-				.WithLocation(10, 19);
+				.WithLocation(8, 19);
 
 			VerifyCSharpDiagnostic(test, diagnostic);
 
@@ -346,8 +340,6 @@ using UnityEngine;
 
 public class Camera : MonoBehaviour
 {
-    public Transform transform;
-
     private void Update()
     {
         Debug.Log(transform.CompareTag(""tag4""));
@@ -365,8 +357,6 @@ using UnityEngine;
 
 public class Camera : MonoBehaviour
 {
-    public Transform transform;
-
     private void Update()
     {
         Debug.Log(null != transform.tag);
@@ -375,7 +365,7 @@ public class Camera : MonoBehaviour
 ";
 
 			var diagnostic = ExpectDiagnostic()
-				.WithLocation(10, 19);
+				.WithLocation(8, 19);
 
 			VerifyCSharpDiagnostic(test, diagnostic);
 
@@ -384,8 +374,6 @@ using UnityEngine;
 
 public class Camera : MonoBehaviour
 {
-    public Transform transform;
-
     private void Update()
     {
         Debug.Log(!transform.CompareTag(null));
@@ -403,8 +391,6 @@ using UnityEngine;
 
 public class Camera : MonoBehaviour
 {
-    public Transform transform;
-
     private void Update()
     {
         if (object.Equals(transform.tag, null))
@@ -414,7 +400,7 @@ public class Camera : MonoBehaviour
 ";
 
 			var diagnostic = ExpectDiagnostic()
-				.WithLocation(10, 13);
+				.WithLocation(8, 13);
 
 			VerifyCSharpDiagnostic(test, diagnostic);
 
@@ -423,8 +409,6 @@ using UnityEngine;
 
 public class Camera : MonoBehaviour
 {
-    public Transform transform;
-
     private void Update()
     {
         if (transform.CompareTag(null))
@@ -443,8 +427,6 @@ using UnityEngine;
 
 public class Camera : MonoBehaviour
 {
-    public Transform transform;
-
     private void Update()
     {
         if (Equals(null, transform.tag))
@@ -454,7 +436,7 @@ public class Camera : MonoBehaviour
 ";
 
 			var diagnostic = ExpectDiagnostic()
-				.WithLocation(10, 13);
+				.WithLocation(8, 13);
 
 			VerifyCSharpDiagnostic(test, diagnostic);
 
@@ -463,8 +445,6 @@ using UnityEngine;
 
 public class Camera : MonoBehaviour
 {
-    public Transform transform;
-
     private void Update()
     {
         if (transform.CompareTag(null))

--- a/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingSuppressorTests.cs
@@ -18,8 +18,8 @@ using UnityEngine;
 
 class Camera : MonoBehaviour
 {
-    public Transform a;
-    public Transform b;
+    public Transform a = null;
+    public Transform b = null;
 
     public Transform NC()
     {

--- a/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingTests.cs
@@ -17,8 +17,8 @@ using UnityEngine;
 
 class Camera : MonoBehaviour
 {
-	public Transform a;
-	public Transform b;
+	public Transform a = null;
+	public Transform b = null;
 
 	public Transform NC()
 	{
@@ -37,8 +37,8 @@ using UnityEngine;
 
 class Camera : MonoBehaviour
 {
-	public Transform a;
-	public Transform b;
+	public Transform a = null;
+	public Transform b = null;
 
 	public Transform NC()
 	{
@@ -57,8 +57,8 @@ using UnityEngine;
 
 class Camera : MonoBehaviour
 {
-	public Transform a;
-	public Transform b;
+	public Transform a = null;
+	public Transform b = null;
 
 	public Transform NC()
 	{
@@ -77,8 +77,8 @@ using UnityEngine;
 
 class Camera : MonoBehaviour
 {
-	public Transform a;
-	public Transform b;
+	public Transform a = null;
+	public Transform b = null;
 
 	public Transform NC()
 	{

--- a/src/Microsoft.Unity.Analyzers/SerializeFieldSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/SerializeFieldSuppressor.cs
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *-------------------------------------------------------------------------------------------*/
 
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;


### PR DESCRIPTION
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Expose all diagnostics to the test infrastructure

#### Changes proposed in this pull request:
Given we now expose all messages, we have to refine several tests, as they are executed in full isolation (no suppressors when testing a regular analyzer/codefix for instance). In extenso, leaving an unused namespace will mark the test as failed.
