### PR TITLE
Modifies InitializeOnLoadStaticCtor analyzer to also find non-static …

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/InitializeOnLoadStaticTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/InitializeOnLoadStaticTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Microsoft.Unity.Analyzers.Tests
 {
-	public class InitializeOnLoadStaticCtorTests : BaseCodeFixVerifierTest<InitializeOnLoadStaticCtorAnalyzer, InitializeOnLoadStaticCtorCodeFix>
+	public class InitializeOnLoadStaticTests : BaseCodeFixVerifierTest<InitializeOnLoadStaticAnalyzer, InitializeOnLoadStaticCodeFix>
 	{
 		[Fact]
 		public void InitializeOnLoadWithoutStaticCtor()
@@ -22,7 +22,7 @@ class Camera : MonoBehaviour
 }
 ";
 
-			var diagnostic = ExpectDiagnostic()
+			var diagnostic = ExpectDiagnostic(InitializeOnLoadStaticAnalyzer.StaticCtorRule)
 				.WithLocation(6, 7)
 				.WithArguments("Camera");
 
@@ -57,7 +57,7 @@ public sealed class Camera : MonoBehaviour
 }
 ";
 
-			var diagnostic = ExpectDiagnostic()
+			var diagnostic = ExpectDiagnostic(InitializeOnLoadStaticAnalyzer.StaticCtorRule)
 				.WithLocation(6, 21)
 				.WithArguments("Camera");
 

--- a/src/Microsoft.Unity.Analyzers/UnityStubs.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityStubs.cs
@@ -306,4 +306,12 @@ namespace UnityEditor
 	class InitializeOnLoadAttribute : System.Attribute
 	{
 	}
+
+	class InitializeOnLoadMethodAttribute : System.Attribute
+	{
+	}
+
+	class RuntimeInitializeOnLoadStaticMethodAttribute : System.Attribute
+	{
+	}
 }


### PR DESCRIPTION
Fixes #29 

#### Checklist
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [ ] I have added tests that prove my fix is effective or that my feature works ;
- [ ] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Verifies the signature of methods adorned with `InitializeOnLoadMethod` and `RuntimeInitializeOnLoadMethod`, ensuring they're static so that Unity will actually call them.

#### TODO
- [X] Modify `InitializeOnLoadStaticCtor` analyzer to support `InitializeOnLoadMethod` and `RuntimeInitializeOnLoadMethod`.
- [ ] Add a code fix for the new diagnostic
- [ ] Add new strings for the new diagnostic
- [ ] Add tests
- [ ] Add docs
