### PR TITLE
Bump Unity to 2018.4.19f1 and salt cache key with unity version

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -27,12 +27,12 @@ jobs:
       id: cache-unity
       uses: actions/cache@v1
       with:
-        key: ${{ runner.os }}-unitycache
+        key: ${{ runner.os }}-unitycache-2018.4.19f1
         path: UnityCache
 
-    - name: Download Unity 2018 LTS
+    - name: Download Unity 2018.4.19f1 LTS
       if: steps.cache-unity.outputs.cache-hit != 'true'
-      run: curl -o ./unity.pkg -k https://download.unity3d.com/download_unity/05119b33d0b7/MacEditorInstaller/Unity.pkg
+      run: curl -o ./unity.pkg -k https://download.unity3d.com/download_unity/459f70f82ea4/MacEditorInstaller/Unity.pkg
 
     - name: Install Unity
       if: steps.cache-unity.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -27,12 +27,12 @@ jobs:
       id: cache-unity
       uses: actions/cache@v1
       with:
-        key: ${{ runner.os }}-unitycache
+        key: ${{ runner.os }}-unitycache-2018.4.19f1
         path: UnityCache
       
-    - name: Download Unity 2018 LTS
+    - name: Download Unity 2018.4.19f1 LTS
       if: steps.cache-unity.outputs.cache-hit != 'true'
-      run: bitsadmin /TRANSFER unity /DOWNLOAD /PRIORITY foreground "https://download.unity3d.com/download_unity/05119b33d0b7/Windows64EditorInstaller/UnitySetup64-2018.4.14f1.exe" "%CD%\unitysetup.exe"
+      run: bitsadmin /TRANSFER unity /DOWNLOAD /PRIORITY foreground "https://download.unity3d.com/download_unity/459f70f82ea4/Windows64EditorInstaller/UnitySetup64-2018.4.19f1.exe" "%CD%\unitysetup.exe"
       shell: cmd
       
     - name: Install Unity


### PR DESCRIPTION
#### Checklist
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;

#### Short description of what this resolves:
Bump Unity to the latest LTS

#### Changes proposed in this pull request:
Bump URLs and salt the cache key with the unity version (to prevent unexpected cache issues)
