### PR TITLE
Add InitializeOnLoadMethodAttribute suppressor

### DIFF
--- a/doc/USP0012.md
+++ b/doc/USP0012.md
@@ -1,0 +1,34 @@
+# USP0012 Don't flag private methods decorated with InitializeOnLoadMethodAttribute as unused
+
+Methods decorated with `InitializeOnLoadMethodAttribute` or `RuntimeInitializeOnLoadMethodAttribute` attributes are not unused.
+
+## Suppressed Diagnostic ID
+
+IDE0051 - Remove unused private members
+
+## Examples of code that produces a suppressed diagnostic
+```csharp
+using UnityEngine;
+using UnityEditor;
+
+class Loader
+{
+    [InitializeOnLoadMethod]
+    private static void OnProjectLoadedInEditor()
+    {
+    }
+
+    [RuntimeInitializeOnLoadMethod]
+    private static void OnSceneLoadedAndGameRunning()
+    {
+    }
+}
+```
+
+## Why is the diagnostic reported?
+
+The IDE cannot find any references to the methods `OnProjectLoadedInEditor` and `OnSceneLoadedAndGameRunning`, and believes them to be unused.
+
+## Why do we suppress this diagnostic?
+
+Even though the IDE cannot find any references to `OnProjectLoadedInEditor` and `OnSceneLoadedAndGameRunning`, they will be called by Unity, and should not be removed.

--- a/src/Microsoft.Unity.Analyzers.Tests/InitializeOnLoadMethodSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/InitializeOnLoadMethodSuppressorTests.cs
@@ -1,0 +1,54 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests
+{
+	public class InitializeOnLoadMethodSuppressorTests : BaseSuppressorVerifierTest<InitializeOnLoadMethodSuppressor>
+	{
+		[Fact]
+		public async Task InitializeOnLoadMethodTest()
+		{
+			const string test = @"
+using UnityEditor;
+
+class Loader
+{
+    [InitializeOnLoadMethod]
+    private static void OnLoad() {
+    }
+}
+";
+
+			var suppressor = ExpectSuppressor(InitializeOnLoadMethodSuppressor.Rule)
+				.WithLocation(7, 25);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+
+		[Fact]
+		public async Task RuntimeInitializeOnLoadMethodTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Loader
+{
+    [RuntimeInitializeOnLoadMethod]
+    private static void OnLoad() {
+    }
+}
+";
+
+			var suppressor = ExpectSuppressor(InitializeOnLoadMethodSuppressor.Rule)
+				.WithLocation(7, 25);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/InitializeOnLoadMethodSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/InitializeOnLoadMethodSuppressor.cs
@@ -1,0 +1,61 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Unity.Analyzers.Resources;
+
+namespace Microsoft.Unity.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class InitializeOnLoadMethodSuppressor : DiagnosticSuppressor
+	{
+		internal static readonly SuppressionDescriptor Rule = new SuppressionDescriptor(
+			id: "USP0012",
+			suppressedDiagnosticId: "IDE0051",
+			justification: Strings.InitializeOnLoadMethodSuppressorJustification);
+
+		public override void ReportSuppressions(SuppressionAnalysisContext context)
+		{
+			foreach (var diagnostic in context.ReportedDiagnostics)
+				AnalyzeDiagnostic(diagnostic, context);
+		}
+
+		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(Rule);
+
+		private static void AnalyzeDiagnostic(Diagnostic diagnostic, SuppressionAnalysisContext context)
+		{
+			var sourceTree = diagnostic.Location.SourceTree;
+			var root = sourceTree.GetRoot(context.CancellationToken);
+			var node = root.FindNode(diagnostic.Location.SourceSpan);
+
+			if (!(node is MethodDeclarationSyntax method))
+				return;
+
+			var model = context.GetSemanticModel(diagnostic.Location.SourceTree);
+			if (!(model.GetDeclaredSymbol(method) is IMethodSymbol methodSymbol))
+				return;
+
+			if (IsSuppressable(methodSymbol))
+				context.ReportSuppression(Suppression.Create(Rule, diagnostic));
+		}
+
+		private static bool IsSuppressable(ISymbol symbol)
+		{
+			return symbol
+				.GetAttributes()
+				.Any(a => IsInitializeOnLoadMethodAttributeType(a.AttributeClass));
+		}
+
+		private static bool IsInitializeOnLoadMethodAttributeType(ITypeSymbol type)
+		{
+			return type.Matches(typeof(UnityEditor.InitializeOnLoadMethodAttribute))
+				|| type.Matches(typeof(UnityEngine.RuntimeInitializeOnLoadMethodAttribute));
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -295,6 +295,15 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t flag private methods decorated with InitializeOnLoadMethodAttribute as unused..
+        /// </summary>
+        internal static string InitializeOnLoadMethodSuppressorJustification {
+            get {
+                return ResourceManager.GetString("InitializeOnLoadMethodSuppressorJustification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add static constructor.
         /// </summary>
         internal static string InitializeOnLoadStaticCtorCodeFixTitle {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -323,4 +323,7 @@
   <data name="GetComponentIncorrectTypeDiagnosticTitle" xml:space="preserve">
     <value>Invalid type for call to GetComponent</value>
   </data>
+  <data name="InitializeOnLoadMethodSuppressorJustification" xml:space="preserve">
+    <value>Don't flag private methods decorated with InitializeOnLoadMethodAttribute as unused.</value>
+  </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/UnityStubs.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityStubs.cs
@@ -215,6 +215,10 @@ namespace UnityEngine
 	class ContextMenuItemAttribute : System.Attribute
 	{
 	}
+
+	class RuntimeInitializeOnLoadMethodAttribute : System.Attribute
+	{
+	}
 }
 
 namespace UnityEngine.EventSystems
@@ -321,6 +325,10 @@ namespace UnityEditor
 	}
 
 	class InitializeOnLoadAttribute : System.Attribute
+	{
+	}
+
+	class InitializeOnLoadMethodAttribute : System.Attribute
 	{
 	}
 }


### PR DESCRIPTION
Fixes #58 

#### Checklist
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Fixed reporting IDE0051 for methods decorated with `InitializeOnLoadMethodAttribute` and `RuntimeInitializeOnLoadMethodAttribute` (InitializeOnLoad_Method_Attribute != InitializeOnLoadAttribute )

#### Changes proposed in this pull request:
Added a new dedicated suppressor