### PR TITLE
Add InitializeOnLoadMethod analyzer

### DIFF
--- a/doc/UNT0009.md
+++ b/doc/UNT0009.md
@@ -1,6 +1,6 @@
 # UNT0009 Missing static constructor with InitializeOnLoad
 
-Provide a static constructor when applying the InitializeOnLoad attribute to a class. This will call it when the editor launches.
+Provide a static constructor when applying the `InitializeOnLoad` attribute to a class. This will call it when the editor launches.
 
 ## Examples of patterns that are flagged by this analyzer
 

--- a/doc/UNT0015.md
+++ b/doc/UNT0015.md
@@ -1,0 +1,33 @@
+# UNT0015 Use a static and parameterless method with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod
+
+Unity needs a method decorated with `InitializeOnLoadMethod` or `RuntimeInitializeOnLoadMethod` attribute to be static and parameterless. Else either Unity won't call it or will throw NullReferenceException.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using UnityEditor;
+
+class Loader
+{
+    [InitializeOnLoadMethod]
+    private void OnLoad(int foo, string bar) {
+    }
+}
+```
+
+## Solution
+
+Fix method signature:
+
+```csharp
+using UnityEditor;
+
+class Loader
+{
+    [InitializeOnLoadMethod]
+    private static void OnLoad() {
+    }
+}
+```
+
+A code fix is offered for this diagnostic to automatically apply this change.

--- a/doc/UNT0015.md
+++ b/doc/UNT0015.md
@@ -1,6 +1,6 @@
 # UNT0015 Incorrect method signature with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod attribute
 
-Unity needs a method decorated with `InitializeOnLoadMethod` or `RuntimeInitializeOnLoadMethod` attribute to be static and parameterless. Else either Unity won't call it or will throw NullReferenceException.
+Unity needs a method decorated with `InitializeOnLoadMethod` or `RuntimeInitializeOnLoadMethod` attribute to be static and parameterless. Otherwise either Unity won't call it or will throw NullReferenceException.
 
 ## Examples of patterns that are flagged by this analyzer
 

--- a/doc/UNT0015.md
+++ b/doc/UNT0015.md
@@ -1,4 +1,4 @@
-# UNT0015 Use a static and parameterless method with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod
+# UNT0015 Incorrect method signature with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod attribute
 
 Unity needs a method decorated with `InitializeOnLoadMethod` or `RuntimeInitializeOnLoadMethod` attribute to be static and parameterless. Else either Unity won't call it or will throw NullReferenceException.
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -16,7 +16,7 @@ ID | Title | Category
 [UNT0012](UNT0012.md) | Unused coroutine return value | Correctness
 [UNT0013](UNT0013.md) | Invalid or redundant SerializeField attribute | Correctness
 [UNT0014](UNT0014.md) | GetComponent called with non-Component or non-Interface type | Type Safety
-[UNT0015](UNT0015.md) | Incorrect message signature with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod attribute | Type Safety
+[UNT0015](UNT0015.md) | Incorrect method signature with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod attribute | Type Safety
 
 # Diagnostic Suppressors
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -16,6 +16,7 @@ ID | Title | Category
 [UNT0012](UNT0012.md) | Unused coroutine return value | Correctness
 [UNT0013](UNT0013.md) | Invalid or redundant SerializeField attribute | Correctness
 [UNT0014](UNT0014.md) | GetComponent called with non-Component or non-Interface type | Type Safety
+[UNT0015](UNT0015.md) | Incorrect message signature with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod attribute | Type Safety
 
 # Diagnostic Suppressors
 
@@ -32,3 +33,4 @@ ID | Suppressed ID | Justification
 [USP0009](USP0009.md) | IDE0051 | Don't flag methods with the ContextMenu attribute or referenced by a field with the ContextMenuItem attribute as unused.
 [USP0010](USP0010.md) | IDE0051 | Don't flag fields with the ContextMenuItem attribute as unused
 [USP0011](USP0011.md) | IDE0044 | Don't make fields with the ContextMenuItem attribute read-only
+[USP0012](USP0012.md) | IDE0051 | Don't flag private methods with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod attribute as unused.

--- a/src/Microsoft.Unity.Analyzers.Tests/InitializeOnLoadMethodTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/InitializeOnLoadMethodTests.cs
@@ -1,0 +1,260 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests
+{
+	public class InitializeOnLoadMethodTests : BaseCodeFixVerifierTest<InitializeOnLoadMethodAnalyzer, InitializeOnLoadMethodCodeFix>
+	{
+		[Fact]
+		public async Task InitializeOnLoadMethodTest()
+		{
+			const string test = @"
+using UnityEditor;
+
+class Loader
+{
+    [InitializeOnLoadMethod]
+    private static void OnLoad() {}
+}";
+
+			await VerifyCSharpDiagnosticAsync(test);
+		}
+
+		[Fact]
+		public async Task InitializeOnLoadMethodFixModifiersTest()
+		{
+			const string test = @"
+using UnityEditor;
+
+class Loader
+{
+    [InitializeOnLoadMethod]
+    private void OnLoad()
+    {
+        // keep
+    }
+}";
+
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(7, 18)
+				.WithArguments("OnLoad");
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+			const string fixedTest = @"
+using UnityEditor;
+
+class Loader
+{
+    [InitializeOnLoadMethod]
+    private static void OnLoad()
+    {
+        // keep
+    }
+}";
+
+			await VerifyCSharpFixAsync(test, fixedTest);
+		}
+
+		[Fact]
+		public async Task InitializeOnLoadMethodFixParametersTest()
+		{
+			const string test = @"
+using UnityEditor;
+
+class Loader
+{
+    [InitializeOnLoadMethod]
+    private static void OnLoad(int foo, string bar)
+    {
+        // keep
+    }
+}";
+
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(7, 25)
+				.WithArguments("OnLoad");
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+			const string fixedTest = @"
+using UnityEditor;
+
+class Loader
+{
+    [InitializeOnLoadMethod]
+    private static void OnLoad()
+    {
+        // keep
+    }
+}";
+
+			await VerifyCSharpFixAsync(test, fixedTest);
+		}
+
+		[Fact]
+		public async Task InitializeOnLoadMethodFixAllTest()
+		{
+			const string test = @"
+using UnityEditor;
+
+class Loader
+{
+    [InitializeOnLoadMethod]
+    private void OnLoad(int foo, string bar)
+    {
+        // keep
+    }
+}";
+
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(7, 18)
+				.WithArguments("OnLoad");
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+			const string fixedTest = @"
+using UnityEditor;
+
+class Loader
+{
+    [InitializeOnLoadMethod]
+    private static void OnLoad()
+    {
+        // keep
+    }
+}";
+
+			await VerifyCSharpFixAsync(test, fixedTest);
+		}
+		
+		[Fact]
+		public async Task RuntimeInitializeOnLoadMethodTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Loader
+{
+    [RuntimeInitializeOnLoadMethod]
+    private static void OnLoad() {
+    }
+}";
+
+			await VerifyCSharpDiagnosticAsync(test);
+		}
+
+		[Fact]
+		public async Task RuntimeInitializeOnLoadMethodFixModifiersTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Loader
+{
+    [RuntimeInitializeOnLoadMethod]
+    private void OnLoad()
+    {
+        // keep
+    }
+}";
+
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(7, 18)
+				.WithArguments("OnLoad");
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+			const string fixedTest = @"
+using UnityEngine;
+
+class Loader
+{
+    [RuntimeInitializeOnLoadMethod]
+    private static void OnLoad()
+    {
+        // keep
+    }
+}";
+
+			await VerifyCSharpFixAsync(test, fixedTest);
+		}
+
+		[Fact]
+		public async Task RuntimeInitializeOnLoadMethodFixParametersTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Loader
+{
+    [RuntimeInitializeOnLoadMethod]
+    private static void OnLoad(int foo, string bar)
+    {
+        // keep
+    }
+}";
+
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(7, 25)
+				.WithArguments("OnLoad");
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+			const string fixedTest = @"
+using UnityEngine;
+
+class Loader
+{
+    [RuntimeInitializeOnLoadMethod]
+    private static void OnLoad()
+    {
+        // keep
+    }
+}";
+
+			await VerifyCSharpFixAsync(test, fixedTest);
+		}
+
+		[Fact]
+		public async Task RuntimeInitializeOnLoadMethodFixAllTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Loader
+{
+    [RuntimeInitializeOnLoadMethod]
+    private void OnLoad(int foo, string bar)
+    {
+        // keep
+    }
+}";
+
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(7, 18)
+				.WithArguments("OnLoad");
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+			const string fixedTest = @"
+using UnityEngine;
+
+class Loader
+{
+    [RuntimeInitializeOnLoadMethod]
+    private static void OnLoad()
+    {
+        // keep
+    }
+}";
+
+			await VerifyCSharpFixAsync(test, fixedTest);
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/InitializeOnLoadMethod.cs
+++ b/src/Microsoft.Unity.Analyzers/InitializeOnLoadMethod.cs
@@ -1,0 +1,128 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Unity.Analyzers.Resources;
+
+namespace Microsoft.Unity.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class InitializeOnLoadMethodAnalyzer : DiagnosticAnalyzer
+	{
+		internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			id: "UNT0015",
+			title: Strings.InitializeOnLoadMethodDiagnosticTitle,
+			messageFormat: Strings.InitializeOnLoadMethodDiagnosticMessageFormat,
+			category: DiagnosticCategory.TypeSafety,
+			defaultSeverity: DiagnosticSeverity.Info,
+			isEnabledByDefault: true,
+			description: Strings.InitializeOnLoadMethodDiagnosticDescription);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.RegisterSyntaxNodeAction(AnalyzeMethodDeclaration, SyntaxKind.MethodDeclaration);
+		}
+
+		internal static bool MethodMatches(SyntaxNode node, SemanticModel model, out MethodDeclarationSyntax syntax, out IMethodSymbol symbol)
+		{
+			syntax = null;
+			symbol = null;
+
+			if (!(node is MethodDeclarationSyntax methodSyntax))
+				return false;
+
+			syntax = methodSyntax;
+
+			if (!(model.GetDeclaredSymbol(methodSyntax) is IMethodSymbol methodSymbol))
+				return false;
+
+			if (!IsDecorated(methodSymbol))
+				return false;
+
+			symbol = methodSymbol;
+			return true;
+		}
+
+		private static bool IsDecorated(ISymbol symbol)
+		{
+			return symbol
+				.GetAttributes()
+				.Any(a => IsInitializeOnLoadMethodAttributeType(a.AttributeClass));
+		}
+
+		private static bool IsInitializeOnLoadMethodAttributeType(ITypeSymbol type)
+		{
+			return type.Matches(typeof(UnityEditor.InitializeOnLoadMethodAttribute))
+			       || type.Matches(typeof(UnityEngine.RuntimeInitializeOnLoadMethodAttribute));
+		}
+
+
+		private static void AnalyzeMethodDeclaration(SyntaxNodeAnalysisContext context)
+		{
+			if (!MethodMatches(context.Node, context.SemanticModel, out var syntax, out var symbol))
+				return;
+
+			if (symbol.IsStatic && symbol.Parameters.Length == 0)
+				return;
+
+			context.ReportDiagnostic(Diagnostic.Create(Rule, syntax.Identifier.GetLocation(), symbol.Name));
+		}
+	}
+
+	[ExportCodeFixProvider(LanguageNames.CSharp)]
+	public class InitializeOnLoadMethodCodeFix : CodeFixProvider
+	{
+		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(InitializeOnLoadMethodAnalyzer.Rule.Id);
+
+		public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+			if (!(root.FindNode(context.Span) is MethodDeclarationSyntax methodDeclaration))
+				return;
+
+			context.RegisterCodeFix(
+				CodeAction.Create(
+					Strings.InitializeOnLoadStaticCtorCodeFixTitle,
+					ct => FixMethodAsync(context.Document, methodDeclaration, ct),
+					methodDeclaration.ToFullString()),
+				context.Diagnostics);
+		}
+
+		private static async Task<Document> FixMethodAsync(Document document, MethodDeclarationSyntax methodDeclaration, CancellationToken ct)
+		{
+			var root = await document
+				.GetSyntaxRootAsync(ct)
+				.ConfigureAwait(false);
+
+			var newMethodDeclaration = methodDeclaration
+				.WithParameterList(SyntaxFactory.ParameterList());
+
+			if (!methodDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword))
+			{
+				newMethodDeclaration = newMethodDeclaration
+					.AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
+			}
+
+			var newRoot = root.ReplaceNode(methodDeclaration, newMethodDeclaration);
+			return document.WithSyntaxRoot(newRoot);
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/InitializeOnLoadMethod.cs
+++ b/src/Microsoft.Unity.Analyzers/InitializeOnLoadMethod.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Unity.Analyzers
 
 			context.RegisterCodeFix(
 				CodeAction.Create(
-					Strings.InitializeOnLoadStaticCtorCodeFixTitle,
+					Strings.InitializeOnLoadMethodCodeFixTitle,
 					ct => FixMethodAsync(context.Document, methodDeclaration, ct),
 					methodDeclaration.ToFullString()),
 				context.Diagnostics);

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use a static and parameterless method.
+        ///   Looks up a localized string similar to Fix method signature.
         /// </summary>
         internal static string InitializeOnLoadMethodCodeFixTitle {
             get {
@@ -322,7 +322,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fix method signature.
+        ///   Looks up a localized string similar to Use a static and parameterless method.
         /// </summary>
         internal static string InitializeOnLoadMethodDiagnosticTitle {
             get {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -295,6 +295,42 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use a static and parameterless method.
+        /// </summary>
+        internal static string InitializeOnLoadMethodCodeFixTitle {
+            get {
+                return ResourceManager.GetString("InitializeOnLoadMethodCodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unity needs a method decorated with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod attribute to be static and parameterless. Else either Unity won&apos;t call it or will throw NullReferenceException..
+        /// </summary>
+        internal static string InitializeOnLoadMethodDiagnosticDescription {
+            get {
+                return ResourceManager.GetString("InitializeOnLoadMethodDiagnosticDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Method &quot;{0}&quot; decorated with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod attribute must be static and parameterless..
+        /// </summary>
+        internal static string InitializeOnLoadMethodDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("InitializeOnLoadMethodDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fix method signature.
+        /// </summary>
+        internal static string InitializeOnLoadMethodDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("InitializeOnLoadMethodDiagnosticTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Don&apos;t flag private methods decorated with InitializeOnLoadMethodAttribute as unused..
         /// </summary>
         internal static string InitializeOnLoadMethodSuppressorJustification {
@@ -322,7 +358,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The class &quot;{0}&quot; tagged with the InitializeOnLoad attribute is missing a static conductor..
+        ///   Looks up a localized string similar to Class &quot;{0}&quot; decorated with the InitializeOnLoad attribute is missing a static conductor..
         /// </summary>
         internal static string InitializeOnLoadStaticCtorDiagnosticMessageFormat {
             get {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -193,7 +193,7 @@
     <value>Provide a static constructor when applying the InitializeOnLoad attribute to a class. This will call it when the editor launches.</value>
   </data>
   <data name="InitializeOnLoadStaticCtorDiagnosticMessageFormat" xml:space="preserve">
-    <value>The class "{0}" tagged with the InitializeOnLoad attribute is missing a static conductor.</value>
+    <value>Class "{0}" decorated with the InitializeOnLoad attribute is missing a static conductor.</value>
   </data>
   <data name="InitializeOnLoadStaticCtorDiagnosticTitle" xml:space="preserve">
     <value>Missing static constructor with InitializeOnLoad</value>
@@ -325,5 +325,18 @@
   </data>
   <data name="InitializeOnLoadMethodSuppressorJustification" xml:space="preserve">
     <value>Don't flag private methods decorated with InitializeOnLoadMethodAttribute as unused.</value>
+  </data>
+  <data name="InitializeOnLoadMethodCodeFixTitle" xml:space="preserve">
+    <value>Use a static and parameterless method</value>
+  </data>
+  <data name="InitializeOnLoadMethodDiagnosticDescription" xml:space="preserve">
+    <value>Unity needs a method decorated with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod attribute to be static and parameterless. Else either Unity won't call it or will throw NullReferenceException.</value>
+  </data>
+  <data name="InitializeOnLoadMethodDiagnosticMessageFormat" xml:space="preserve">
+    <value>Method "{0}" decorated with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod attribute must be static and parameterless.</value>
+    <comment>{0} is an identifier declared with a *InitializeOnLoadMethod attribute</comment>
+  </data>
+  <data name="InitializeOnLoadMethodDiagnosticTitle" xml:space="preserve">
+    <value>Fix method signature</value>
   </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -327,7 +327,7 @@
     <value>Don't flag private methods decorated with InitializeOnLoadMethodAttribute as unused.</value>
   </data>
   <data name="InitializeOnLoadMethodCodeFixTitle" xml:space="preserve">
-    <value>Use a static and parameterless method</value>
+    <value>Fix method signature</value>
   </data>
   <data name="InitializeOnLoadMethodDiagnosticDescription" xml:space="preserve">
     <value>Unity needs a method decorated with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod attribute to be static and parameterless. Else either Unity won't call it or will throw NullReferenceException.</value>
@@ -337,6 +337,6 @@
     <comment>{0} is an identifier declared with a *InitializeOnLoadMethod attribute</comment>
   </data>
   <data name="InitializeOnLoadMethodDiagnosticTitle" xml:space="preserve">
-    <value>Fix method signature</value>
+    <value>Use a static and parameterless method</value>
   </data>
 </root>


### PR DESCRIPTION
Fixes #29 

#### Checklist
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Checks for valid method signature when decorated with `InitializeOnLoadMethodAttribute` or `RuntimeInitializeOnLoadMethod` attributes.

#### Changes proposed in this pull request:
Discussed in #50:

> In the end, I think it's better to create a new analyzer/codefix.
> 
> The current analyzer is working with `InitializeOnLoadAttribute`, working at a **type** level. When a static ctor is not here, the 'fix' is to **create one**.
> 
> `InitializeOnLoadMethodAttribute` and `RuntimeInitializeOnLoadMethod` are working on a **method** level. When the method signature/modifiers are incorrect, the 'fix' is to **correct** the method signature/modifiers in-place.
> 
> So even if the work seems quite similar, the analysis and the fix are different for both cases.
> 
> So I'm closing this and going to create a new PR.
> 

I also updated the existing `InitializeOnLoadAttribute` suppressor to reuse the same detection logic