### PR TITLE
Method invocation analyzer

### DIFF
--- a/doc/UNT0016.md
+++ b/doc/UNT0016.md
@@ -1,0 +1,59 @@
+# UNT0016 Unsafe way to get the method name
+
+Using `Invoke`, `InvokeRepeating`, `StartCoroutine` or `StopCoroutine` with a first argument being a string literal is not type safe. Instead it's recommanded to use the `nameof` operator or a direct call for coroutines. The further benefit of doing this is the ability for the method to use a rename refactoring without remembering to update the string literals.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using UnityEngine;
+using System.Collections;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+	    Invoke("InvokeMe", 10.0f)
+        StartCoroutine("MyCoroutine");
+    }
+
+    private void InvokeMe()
+    {
+		// ...
+    }
+
+    private IEnumerator MyCoroutine()
+    {
+		// ...
+    }
+}
+```
+
+## Solution
+
+Use `nameof` or direct call for coroutines.
+
+```csharp
+using UnityEngine;
+using System.Collections;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+	    Invoke(nameof(InvokeMe), 10.0f)
+        StartCoroutine(MyCoroutine());
+    }
+
+    private void InvokeMe()
+    {
+		// ...
+    }
+
+    private IEnumerator MyCoroutine()
+    {
+		// ...
+    }
+}
+```
+
+Code fixes are offered for this diagnostic to automatically apply those changes.

--- a/doc/UNT0016.md
+++ b/doc/UNT0016.md
@@ -12,18 +12,18 @@ class Camera : MonoBehaviour
 {
     void Start()
     {
-	    Invoke("InvokeMe", 10.0f)
+        Invoke("InvokeMe", 10.0f)
         StartCoroutine("MyCoroutine");
     }
 
     private void InvokeMe()
     {
-		// ...
+        // ...
     }
 
     private IEnumerator MyCoroutine()
     {
-		// ...
+        // ...
     }
 }
 ```
@@ -40,18 +40,18 @@ class Camera : MonoBehaviour
 {
     void Start()
     {
-	    Invoke(nameof(InvokeMe), 10.0f)
+        Invoke(nameof(InvokeMe), 10.0f)
         StartCoroutine(MyCoroutine());
     }
 
     private void InvokeMe()
     {
-		// ...
+        // ...
     }
 
     private IEnumerator MyCoroutine()
     {
-		// ...
+        // ...
     }
 }
 ```

--- a/doc/index.md
+++ b/doc/index.md
@@ -16,6 +16,7 @@ ID | Title | Category
 [UNT0012](UNT0012.md) | Unused coroutine return value | Correctness
 [UNT0013](UNT0013.md) | Invalid or redundant SerializeField attribute | Correctness
 [UNT0014](UNT0014.md) | GetComponent called with non-Component or non-Interface type | Type Safety
+[UNT0016](UNT0016.md) | Unsafe way to get the method name | Type Safety
 
 # Diagnostic Suppressors
 

--- a/src/Microsoft.Unity.Analyzers.Tests/MethodInvocationDirectCallTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/MethodInvocationDirectCallTests.cs
@@ -1,0 +1,105 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests
+{
+	public class MethodInvocationDirectCallTests : BaseCodeFixVerifierTest<MethodInvocationAnalyzer, MethodInvocationDirectCallCodeFix>
+	{
+		[Fact]
+		public async Task TestStartCoroutine()
+		{
+			const string test = @"
+using UnityEngine;
+using System.Collections;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+        StartCoroutine(""InvokeMe"");
+    }
+
+    private IEnumerator InvokeMe()
+    {
+		return null;
+    }
+}";
+
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(9, 9)
+				.WithArguments("InvokeMe");
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+			const string fixedTest = @"
+using UnityEngine;
+using System.Collections;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+        StartCoroutine(InvokeMe());
+    }
+
+    private IEnumerator InvokeMe()
+    {
+		return null;
+    }
+}";
+
+			await VerifyCSharpFixAsync(test, fixedTest);
+		}
+
+		[Fact]
+		public async Task TestStopCoroutine()
+		{
+			const string test = @"
+using UnityEngine;
+using System.Collections;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+        StopCoroutine(""InvokeMe"");
+    }
+
+    private IEnumerator InvokeMe()
+    {
+		return null;
+    }
+}";
+
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(9, 9)
+				.WithArguments("InvokeMe");
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+			const string fixedTest = @"
+using UnityEngine;
+using System.Collections;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+        StopCoroutine(InvokeMe());
+    }
+
+    private IEnumerator InvokeMe()
+    {
+		return null;
+    }
+}";
+
+			await VerifyCSharpFixAsync(test, fixedTest);
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers.Tests/MethodInvocationNameOfTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/MethodInvocationNameOfTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.Unity.Analyzers.Tests
 {
-	public class MethodInvocationTests : BaseCodeFixVerifierTest<MethodInvocationAnalyzer, MethodInvocationCodeFix>
+	public class MethodInvocationNameOfTests : BaseCodeFixVerifierTest<MethodInvocationAnalyzer, MethodInvocationNameOfCodeFix>
 	{
 		[Fact]
 		public async Task TestInvoke()
@@ -29,7 +29,8 @@ class Camera : MonoBehaviour
 }";
 
 			var diagnostic = ExpectDiagnostic()
-				.WithLocation(8, 9);
+				.WithLocation(8, 9)
+				.WithArguments("InvokeMe");
 
 			await VerifyCSharpDiagnosticAsync(test, diagnostic);
 
@@ -70,7 +71,8 @@ class Camera : MonoBehaviour
 }";
 
 			var diagnostic = ExpectDiagnostic()
-				.WithLocation(8, 9);
+				.WithLocation(8, 9)
+				.WithArguments("InvokeMe");
 
 			await VerifyCSharpDiagnosticAsync(test, diagnostic);
 
@@ -115,5 +117,96 @@ class Foo
 			await VerifyCSharpDiagnosticAsync(test);
 		}
 
+		[Fact]
+		public async Task TestStartCoroutine()
+		{
+			const string test = @"
+using UnityEngine;
+using System.Collections;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+        StartCoroutine(""InvokeMe"");
+    }
+
+    private IEnumerator InvokeMe()
+    {
+		return null;
+    }
+}";
+
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(9, 9)
+				.WithArguments("InvokeMe");
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+			const string fixedTest = @"
+using UnityEngine;
+using System.Collections;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+        StartCoroutine(nameof(InvokeMe));
+    }
+
+    private IEnumerator InvokeMe()
+    {
+		return null;
+    }
+}";
+
+			await VerifyCSharpFixAsync(test, fixedTest);
+		}
+
+		[Fact]
+		public async Task TestStopCoroutine()
+		{
+			const string test = @"
+using UnityEngine;
+using System.Collections;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+        StopCoroutine(""InvokeMe"");
+    }
+
+    private IEnumerator InvokeMe()
+    {
+		return null;
+    }
+}";
+
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(9, 9)
+				.WithArguments("InvokeMe");
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+			const string fixedTest = @"
+using UnityEngine;
+using System.Collections;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+        StopCoroutine(nameof(InvokeMe));
+    }
+
+    private IEnumerator InvokeMe()
+    {
+		return null;
+    }
+}";
+
+			await VerifyCSharpFixAsync(test, fixedTest);
+		}
 	}
 }

--- a/src/Microsoft.Unity.Analyzers.Tests/MethodInvocationTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/MethodInvocationTests.cs
@@ -1,0 +1,119 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests
+{
+	public class MethodInvocationTests : BaseCodeFixVerifierTest<MethodInvocationAnalyzer, MethodInvocationCodeFix>
+	{
+		[Fact]
+		public async Task TestInvoke()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+        Invoke(""InvokeMe"", 10.0f);
+    }
+
+    private void InvokeMe()
+    {
+    }
+}";
+
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(8, 9);
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+			const string fixedTest = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+        Invoke(nameof(InvokeMe), 10.0f);
+    }
+
+    private void InvokeMe()
+    {
+    }
+}";
+
+			await VerifyCSharpFixAsync(test, fixedTest);
+		}
+
+		[Fact]
+		public async Task TestInvokeRepeating()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+        InvokeRepeating(""InvokeMe"", 10.0f, 10.0f);
+    }
+
+    private void InvokeMe()
+    {
+    }
+}";
+
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(8, 9);
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+			const string fixedTest = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    void Start()
+    {
+        InvokeRepeating(nameof(InvokeMe), 10.0f, 10.0f);
+    }
+
+    private void InvokeMe()
+    {
+    }
+}";
+
+			await VerifyCSharpFixAsync(test, fixedTest);
+		}
+
+		[Fact]
+		public async Task TestInvokeNoMonoBehaviour()
+		{
+			const string test = @"
+class Foo
+{
+    void Bar()
+    {
+        this.Invoke(""InvokeMe"", 10.0f);
+    }
+
+    private void Invoke(string name, object param) 
+    {
+    }
+
+    private void InvokeMe()
+    {
+    }
+}";
+
+			await VerifyCSharpDiagnosticAsync(test);
+		}
+
+	}
+}

--- a/src/Microsoft.Unity.Analyzers.Tests/UnusedMethodSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnusedMethodSuppressorTests.cs
@@ -34,5 +34,34 @@ class Camera : MonoBehaviour
 
 			await VerifyCSharpDiagnosticAsync(test, suppressor);
 		}
+
+		[Fact]
+		public async Task UnusedMethodMixedTypes()
+		{
+			const string test = @"
+using UnityEngine;
+
+class A : MonoBehaviour
+{
+    private B b = null;
+
+    public void Update()
+    {
+        b.InvokeRepeating(""Foo"", 1.0f, 1.0f);
+    }
+
+    class B : MonoBehaviour
+    {
+        void Foo()
+        {
+        }
+    }
+}";
+
+			var suppressor = ExpectSuppressor(UnusedMethodSuppressor.Rule)
+				.WithLocation(15, 14);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
+++ b/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
@@ -1,0 +1,160 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.Unity.Analyzers.Resources;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Unity.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class MethodInvocationAnalyzer : DiagnosticAnalyzer
+	{
+		internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			id: "UNT0015",
+			title: Strings.MethodInvocationDiagnosticTitle,
+			messageFormat: Strings.MethodInvocationDiagnosticMessageFormat,
+			category: DiagnosticCategory.TypeSafety,
+			defaultSeverity: DiagnosticSeverity.Info,
+			isEnabledByDefault: true,
+			description: Strings.MethodInvocationDiagnosticDescription);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+		}
+
+		// TODO we cannot add this to our stubs/KnownMethods so far (else they will be matched as Unity messages)
+		private static readonly HashSet<string> MethodNames = new HashSet<string>(new[] {"Invoke", "InvokeRepeating", "StartCoroutine", "StopCoroutine"});
+
+		private static bool InvocationMatches(SyntaxNode node)
+		{
+			switch (node)
+			{
+				case InvocationExpressionSyntax ies:
+					return InvocationMatches(ies.Expression);
+				case MemberAccessExpressionSyntax maes:
+					return InvocationMatches(maes.Name);
+				case IdentifierNameSyntax ins:
+					return MethodNames.Contains(ins.Identifier.Text);
+				default:
+					return false;
+			}
+		}
+
+		internal static bool InvocationMatches(InvocationExpressionSyntax ies, out string argument)
+		{
+			argument = null;
+
+			if (!InvocationMatches(ies))
+				return false;
+
+			var args = ies.ArgumentList.Arguments;
+
+			if (args.Count <= 0)
+				return false;
+
+			if (!(args.First().Expression is LiteralExpressionSyntax les))
+				return false;
+
+			argument = les.Token.ValueText;
+
+			return true;
+		}
+
+		private void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+		{
+			if (!(context.Node is InvocationExpressionSyntax invocation))
+				return;
+
+			var options = invocation.SyntaxTree?.Options as CSharpParseOptions;
+			if (options == null || options.LanguageVersion < LanguageVersion.CSharp6) // we want nameof support
+				return;
+
+			if (!InvocationMatches(invocation, out _))
+				return;
+
+			var model = context.SemanticModel;
+			if (!(model.GetSymbolInfo(invocation.Expression).Symbol is IMethodSymbol methodSymbol))
+				return;
+
+			var typeSymbol = methodSymbol.ContainingType;
+			if (!typeSymbol.Extends(typeof(UnityEngine.MonoBehaviour)))
+				return;
+
+			context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
+		}
+	}
+
+	[ExportCodeFixProvider(LanguageNames.CSharp)]
+	public class MethodInvocationCodeFix : CodeFixProvider
+	{
+		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(MethodInvocationAnalyzer.Rule.Id);
+
+		public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+			if (!(root.FindNode(context.Span) is InvocationExpressionSyntax invocation))
+				return;
+
+			context.RegisterCodeFix(
+				CodeAction.Create(
+					Strings.MethodInvocationCodeFixTitle,
+					ct => UseNameOfAsync(context.Document, invocation, ct),
+					invocation.ToFullString()),
+				context.Diagnostics);
+		}
+
+		private async Task<Document> UseNameOfAsync(Document document, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
+		{
+			var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+			// We already know that we have at least one string argument
+			var les = (LiteralExpressionSyntax)invocation.ArgumentList.Arguments[0].Expression;
+			var name = les.Token.ValueText;
+
+			var nameof = IdentifierName(
+				Identifier(
+					TriviaList(),
+					SyntaxKind.NameOfKeyword,
+					"nameof",
+					"nameof",
+					TriviaList()));
+
+			var newArgument = Argument(
+				InvocationExpression(nameof)
+					.WithArgumentList(
+						ArgumentList(
+							SingletonSeparatedList(
+								Argument(
+									IdentifierName(name))))));
+
+			var newInvocation = invocation
+				.WithAdditionalAnnotations(Formatter.Annotation)
+				.WithArgumentList(invocation.ArgumentList.ReplaceNode(invocation.ArgumentList.Arguments[0], newArgument));
+
+			var newRoot = root.ReplaceNode(invocation, newInvocation);
+			return document.WithSyntaxRoot(newRoot);
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
+++ b/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Unity.Analyzers
 		{
 			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-			if (!(root.FindNode(context.Span) is InvocationExpressionSyntax invocation))
+			if (!(root?.FindNode(context.Span) is InvocationExpressionSyntax invocation))
 				return;
 
 			if (! await IsRegistrableAsync(context, invocation))

--- a/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
+++ b/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
@@ -145,6 +145,8 @@ namespace Microsoft.Unity.Analyzers
 				return true;
 
 			var typeInvocationContext = model.GetTypeInfo(maes.ChildNodes().FirstOrDefault()).Type as INamedTypeSymbol;
+			if (typeInvocationContext == null)
+				return false;
 
 			var mdec = invocation
 				.Ancestors()
@@ -155,9 +157,9 @@ namespace Microsoft.Unity.Analyzers
 				return false;
 
 			var symbol = model.GetDeclaredSymbol(mdec);
-			var typeContext = symbol.ContainingType;
+			var typeContext = symbol?.ContainingType;
 
-			return typeContext.Equals(typeInvocationContext);
+			return typeContext != null && typeContext.Equals(typeInvocationContext);
 		}
 
 		protected abstract ArgumentSyntax GetArgument(string name);

--- a/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
+++ b/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Unity.Analyzers
 			var symbol = model.GetDeclaredSymbol(mdec);
 			var typeContext = symbol?.ContainingType;
 
-			return typeContext != null && typeContext.Equals(typeInvocationContext);
+			return typeContext != null && SymbolEqualityComparer.Default.Equals(typeContext, typeInvocationContext);
 		}
 
 		protected abstract ArgumentSyntax GetArgument(string name);

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -376,16 +376,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use nameof operator instead of a string literal.
-        /// </summary>
-        internal static string MethodInvocationCodeFixTitle {
-            get {
-                return ResourceManager.GetString("MethodInvocationCodeFixTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to TODO: Add description..
+        ///   Looks up a localized string similar to Usage of nameof or direct call is preferred for type safety..
         /// </summary>
         internal static string MethodInvocationDiagnosticDescription {
             get {
@@ -394,7 +385,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to TODO: Add Message format.
+        ///   Looks up a localized string similar to Method &quot;{0}&quot; is invoked using a string literal..
         /// </summary>
         internal static string MethodInvocationDiagnosticMessageFormat {
             get {
@@ -403,11 +394,29 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to TODO: Add title.
+        ///   Looks up a localized string similar to Unsafe way to get the method name.
         /// </summary>
         internal static string MethodInvocationDiagnosticTitle {
             get {
                 return ResourceManager.GetString("MethodInvocationDiagnosticTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use direct call.
+        /// </summary>
+        internal static string MethodInvocationDirectCallCodeFixTitle {
+            get {
+                return ResourceManager.GetString("MethodInvocationDirectCallCodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use nameof operator.
+        /// </summary>
+        internal static string MethodInvocationNameOfCodeFixTitle {
+            get {
+                return ResourceManager.GetString("MethodInvocationNameOfCodeFixTitle", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -376,6 +376,42 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use nameof operator instead of a string literal.
+        /// </summary>
+        internal static string MethodInvocationCodeFixTitle {
+            get {
+                return ResourceManager.GetString("MethodInvocationCodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TODO: Add description..
+        /// </summary>
+        internal static string MethodInvocationDiagnosticDescription {
+            get {
+                return ResourceManager.GetString("MethodInvocationDiagnosticDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TODO: Add Message format.
+        /// </summary>
+        internal static string MethodInvocationDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("MethodInvocationDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TODO: Add title.
+        /// </summary>
+        internal static string MethodInvocationDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("MethodInvocationDiagnosticTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Don&apos;t flag fields with a SerializeField or SerializeReference attribute as never assigned..
         /// </summary>
         internal static string NeverAssignedSerializeFieldSuppressorJustification {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -326,16 +326,19 @@
   <data name="InitializeOnLoadMethodSuppressorJustification" xml:space="preserve">
     <value>Don't flag private methods decorated with InitializeOnLoadMethodAttribute as unused.</value>
   </data>
-  <data name="MethodInvocationCodeFixTitle" xml:space="preserve">
-    <value>Use nameof operator instead of a string literal</value>
+  <data name="MethodInvocationNameOfCodeFixTitle" xml:space="preserve">
+    <value>Use nameof operator</value>
   </data>
   <data name="MethodInvocationDiagnosticDescription" xml:space="preserve">
-    <value>TODO: Add description.</value>
+    <value>Usage of nameof or direct call is preferred for type safety.</value>
   </data>
   <data name="MethodInvocationDiagnosticMessageFormat" xml:space="preserve">
-    <value>TODO: Add Message format</value>
+    <value>Method "{0}" is invoked using a string literal.</value>
   </data>
   <data name="MethodInvocationDiagnosticTitle" xml:space="preserve">
-    <value>TODO: Add title</value>
+    <value>Unsafe way to get the method name</value>
+  </data>
+  <data name="MethodInvocationDirectCallCodeFixTitle" xml:space="preserve">
+    <value>Use direct call</value>
   </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -326,4 +326,16 @@
   <data name="InitializeOnLoadMethodSuppressorJustification" xml:space="preserve">
     <value>Don't flag private methods decorated with InitializeOnLoadMethodAttribute as unused.</value>
   </data>
+  <data name="MethodInvocationCodeFixTitle" xml:space="preserve">
+    <value>Use nameof operator instead of a string literal</value>
+  </data>
+  <data name="MethodInvocationDiagnosticDescription" xml:space="preserve">
+    <value>TODO: Add description.</value>
+  </data>
+  <data name="MethodInvocationDiagnosticMessageFormat" xml:space="preserve">
+    <value>TODO: Add Message format</value>
+  </data>
+  <data name="MethodInvocationDiagnosticTitle" xml:space="preserve">
+    <value>TODO: Add title</value>
+  </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/UnusedMethodSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/UnusedMethodSuppressor.cs
@@ -48,6 +48,9 @@ namespace Microsoft.Unity.Analyzers
 			if (!typeSymbol.Extends(typeof(UnityEngine.MonoBehaviour)))
 				return;
 
+			while (typeSymbol.ContainingType != null && typeSymbol.ContainingType.Extends(typeof(UnityEngine.MonoBehaviour)))
+				typeSymbol = typeSymbol.ContainingType;
+
 			var references = new List<InvocationExpressionSyntax>();
 			foreach (var typeNode in typeSymbol.Locations.Select(location => root.FindNode(location.SourceSpan)))
 			{

--- a/src/Microsoft.Unity.Analyzers/UnusedMethodSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/UnusedMethodSuppressor.cs
@@ -31,8 +31,6 @@ namespace Microsoft.Unity.Analyzers
 
 		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(Rule);
 
-		private static readonly HashSet<string> MethodNames = new HashSet<string>(new[] {"Invoke", "InvokeRepeating", "StartCoroutine", "StopCoroutine"});
-
 		private static void AnalyzeDiagnostic(Diagnostic diagnostic, SuppressionAnalysisContext context)
 		{
 			var sourceTree = diagnostic.Location.SourceTree;
@@ -50,40 +48,16 @@ namespace Microsoft.Unity.Analyzers
 			if (!typeSymbol.Extends(typeof(UnityEngine.MonoBehaviour)))
 				return;
 
-			var references = root
-				.DescendantNodes()
-				.OfType<InvocationExpressionSyntax>()
-				.Where(e => IsMatchingArgument(e, methodSymbol.Name))
-				.Where(e => IsMatchingIdentifier(e.Expression));
+			var references = new List<InvocationExpressionSyntax>();
+			foreach (var typeNode in typeSymbol.Locations.Select(location => root.FindNode(location.SourceSpan)))
+			{
+				references.AddRange(typeNode.DescendantNodes()
+					.OfType<InvocationExpressionSyntax>()
+					.Where(e => MethodInvocationAnalyzer.InvocationMatches(e, out string argument) && argument == methodSymbol.Name));
+			}
 
 			if (references.Any())
 				context.ReportSuppression(Suppression.Create(Rule, diagnostic));
-		}
-
-		private static bool IsMatchingIdentifier(SyntaxNode sn)
-		{
-			switch (sn)
-			{
-				case MemberAccessExpressionSyntax maes:
-					return IsMatchingIdentifier(maes.Name);
-				case IdentifierNameSyntax ins:
-					return MethodNames.Contains(ins.Identifier.Text);
-				default:
-					return false;
-			}
-		}
-
-		private static bool IsMatchingArgument(InvocationExpressionSyntax ies, string name)
-		{
-			var args = ies.ArgumentList.Arguments;
-
-			if (args.Count <= 0)
-				return false;
-
-			if (!(args.First().Expression is LiteralExpressionSyntax les))
-				return false;
-
-			return name == les.Token.ValueText;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #37 and #65

#### Checklist
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Using `Invoke`, `InvokeRepeating`, `StartCoroutine` or `StopCoroutine` with a first argument being a string literal is not type safe. Instead it's recommanded to use the `nameof` operator or a direct call for coroutines. The further benefit of doing this is the ability for the method to use a rename refactoring without remembering to update the string literals.

#### Changes proposed in this pull request:
Added one diagnostic and two code fixes.

Note that `ConsistencyTests` will fail because of the analyzer ID. That's expected while all other PRs are not yet merged.
