### PR TITLE
Disable consistency tests for feature branches

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -56,12 +56,14 @@ jobs:
 
     - name: Test context (master)
       if: github.ref == 'refs/heads/master'
-      env: TEST_FILTER: .
+      env: 
+        TEST_FILTER: .
       run: echo enabling consistency tests
     
     - name: Test context (feature)    
       if: github.ref != 'refs/heads/master'
-      env: TEST_FILTER: FullyQualifiedName!~ConsistencyTests
+      env: 
+        TEST_FILTER: FullyQualifiedName!~ConsistencyTests
       run: echo disabling consistency tests
       
     - name: Test

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -67,7 +67,7 @@ jobs:
       run: echo disabling consistency tests
       
     - name: Test
-      run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter ${{TEST_FILTER}}
+      run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter ${{env.TEST_FILTER}}
       env:
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
         DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -67,7 +67,7 @@ jobs:
       run: echo disabling consistency tests
       
     - name: Test
-      run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter $TEST_FILTER
+      run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter ${{TEST_FILTER}}
       env:
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
         DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -56,15 +56,11 @@ jobs:
 
     - name: Test context (master)
       if: github.ref == 'refs/heads/master'
-      env: 
-        TEST_FILTER: .
-      run: echo enabling consistency tests
+      run: echo "::set-env name=TEST_FILTER::."
     
     - name: Test context (feature)    
       if: github.ref != 'refs/heads/master'
-      env: 
-        TEST_FILTER: FullyQualifiedName!~ConsistencyTests
-      run: echo disabling consistency tests
+      run: echo "::set-env name=TEST_FILTER::FullyQualifiedName!~ConsistencyTests"
       
     - name: Test
       run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter ${{env.TEST_FILTER}}

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -56,13 +56,13 @@ jobs:
 
     - name: Test context (master)
       if: github.ref == 'refs/heads/master'
-      env: 
-        TEST_FILTER: .
+      env: TEST_FILTER: .
+      run: echo enabling consistency tests
     
     - name: Test context (feature)    
       if: github.ref != 'refs/heads/master'
-      env: 
-        TEST_FILTER: FullyQualifiedName!~ConsistencyTests
+      env: TEST_FILTER: FullyQualifiedName!~ConsistencyTests
+      run: echo disabling consistency tests
       
     - name: Test
       run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter $TEST_FILTER

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -54,8 +54,18 @@ jobs:
       if: steps.cache-unity.outputs.cache-hit == 'true'
       run: sudo ditto UnityCache/MonoBleedingEdge/ /Applications/Unity/Unity.app/Contents/MonoBleedingEdge/
 
+    - name: Test context (master)
+      if: github.ref == 'refs/heads/master'
+      env: 
+        TEST_FILTER: .
+    
+    - name: Test context (feature)    
+      if: github.ref != 'refs/heads/master'
+      env: 
+        TEST_FILTER: FullyQualifiedName!~ConsistencyTests
+      
     - name: Test
-      run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests
+      run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter $TEST_FILTER
       env:
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
         DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -59,9 +59,19 @@ jobs:
       if: steps.cache-unity.outputs.cache-hit == 'true'
       run: xcopy /s /i /y /q "UnityCache\MonoBleedingEdge" "C:\Program Files\Unity\Editor\Data\MonoBleedingEdge"
       shell: cmd
+      
+    - name: Test context (master)
+      if: github.ref == 'refs/heads/master'
+      env: 
+        TEST_FILTER: .
+    
+    - name: Test context (feature)    
+      if: github.ref != 'refs/heads/master'
+      env: 
+        TEST_FILTER: FullyQualifiedName!~ConsistencyTests
 
     - name: Test
-      run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests
+      run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter $TEST_FILTER
       env:
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
         DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -62,12 +62,14 @@ jobs:
       
     - name: Test context (master)
       if: github.ref == 'refs/heads/master'
-      env: TEST_FILTER: .
+      env: 
+        TEST_FILTER: .
       run: echo enabling consistency tests
 
     - name: Test context (feature)    
       if: github.ref != 'refs/heads/master'
-      env: TEST_FILTER: FullyQualifiedName!~ConsistencyTests
+      env: 
+        TEST_FILTER: FullyQualifiedName!~ConsistencyTests
       run: echo disabling consistency tests
 
     - name: Test

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -62,15 +62,11 @@ jobs:
       
     - name: Test context (master)
       if: github.ref == 'refs/heads/master'
-      env: 
-        TEST_FILTER: .
-      run: echo enabling consistency tests
-
+      run: echo "::set-env name=TEST_FILTER::."
+    
     - name: Test context (feature)    
       if: github.ref != 'refs/heads/master'
-      env: 
-        TEST_FILTER: FullyQualifiedName!~ConsistencyTests
-      run: echo disabling consistency tests
+      run: echo "::set-env name=TEST_FILTER::FullyQualifiedName!~ConsistencyTests"
 
     - name: Test
       run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter ${{env.TEST_FILTER}}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -73,7 +73,7 @@ jobs:
       run: echo disabling consistency tests
 
     - name: Test
-      run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter ${{TEST_FILTER}}
+      run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter ${{env.TEST_FILTER}}
       env:
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
         DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -62,13 +62,13 @@ jobs:
       
     - name: Test context (master)
       if: github.ref == 'refs/heads/master'
-      env: 
-        TEST_FILTER: .
-    
+      env: TEST_FILTER: .
+      run: echo enabling consistency tests
+
     - name: Test context (feature)    
       if: github.ref != 'refs/heads/master'
-      env: 
-        TEST_FILTER: FullyQualifiedName!~ConsistencyTests
+      env: TEST_FILTER: FullyQualifiedName!~ConsistencyTests
+      run: echo disabling consistency tests
 
     - name: Test
       run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter $TEST_FILTER

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -73,7 +73,7 @@ jobs:
       run: echo disabling consistency tests
 
     - name: Test
-      run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter $TEST_FILTER
+      run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter ${{TEST_FILTER}}
       env:
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
         DOTNET_CLI_TELEMETRY_OPTOUT: true


### PR DESCRIPTION
#### Checklist
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;

#### Short description of what this resolves:
Consistency tests (for suppressor/analyzer ids) are not useful when we have multiple PR waiting for validation.

Let's run them only on the master branch.
