### PR TITLE
Bump baseline to 16.4/8.4/Roslyn 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ If you have an idea for a best practice for Unity developers to follow, please o
 # Prerequisites
 For building and testing, you'll need the **.NET Core SDK Version 3.1.100 (LTS)**.
 
-This project is using the `DiagnosticSuppressor` API to conditionally suppress reported compiler/analyzer diagnostics. This API is available starting with **Visual Studio 2019 16.3** or **Visual Studio for Mac 8.3**.
+This project is targeting **Visual Studio 2019 16.4** and **Visual Studio for Mac 8.4**.
+
+This project is using the `DiagnosticSuppressor` API to conditionally suppress reported compiler/analyzer diagnostics. 
 
 On Windows, you'll need the _Visual Studio extension development_ workload installed to build a VSIX to use and debug the project in Visual Studio.
 

--- a/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
+++ b/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.6" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-3.20177.13" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />    
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="all" />

--- a/src/Microsoft.Unity.Analyzers/Microsoft.Unity.Analyzers.csproj
+++ b/src/Microsoft.Unity.Analyzers/Microsoft.Unity.Analyzers.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.4" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.6" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.5.132" PrivateAssets="all" />	
   </ItemGroup>
   


### PR DESCRIPTION
#### Checklist
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;

#### Short description of what this resolves:
Bump Roslyn-related assemblies to 3.4 (compatible with VS 16.4, VSM 8.4)
