### PR TITLE
Check generic type parameters in UNT0014 diagnostic

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/GetComponentIncorrectTypeTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/GetComponentIncorrectTypeTests.cs
@@ -91,5 +91,81 @@ class Camera : MonoBehaviour
 ";
 			await VerifyCSharpDiagnosticAsync(test);
 		}
+
+		[Fact]
+		public async Task GetGenericMethodComponentCorrectTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private void Method<T>() where T : Component
+    {
+        var hello = GetComponent<T>();
+    }
+}
+";
+			await VerifyCSharpDiagnosticAsync(test);
+		}
+
+		[Fact]
+		public async Task GetGenericMethodComponentIncorrectTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private void Method<T>()
+    {
+        GetComponent<T>();
+    }
+}
+";
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(8, 9)
+				.WithArguments("T");
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+		}
+
+		[Fact]
+		public async Task GetGenericClassComponentCorrectTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera<T> : MonoBehaviour where T : Component
+{
+    private void Method()
+    {
+        var hello = GetComponent<T>();
+    }
+}
+";
+			await VerifyCSharpDiagnosticAsync(test);
+		}
+
+		[Fact]
+		public async Task GetGenericClassComponentIncorrectTest()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera<T> : MonoBehaviour
+{
+    private void Method()
+    {
+        GetComponent<T>();
+    }
+}
+";
+			var diagnostic = ExpectDiagnostic()
+				.WithLocation(8, 9)
+				.WithArguments("T");
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+		}
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
+++ b/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
@@ -63,6 +63,12 @@ namespace Microsoft.Unity.Analyzers
 			if (argumentType.Extends(typeof(UnityEngine.Component)) || argumentType.TypeKind == TypeKind.Interface)
 				return false;
 
+			if (argumentType.TypeKind == TypeKind.TypeParameter && argumentType is ITypeParameterSymbol typeParameter)
+			{
+				if (typeParameter.ConstraintTypes.Any(t => t.Extends(typeof(UnityEngine.Component))))
+					return false;
+			}
+
 			identifier = argumentType.Name;
 			return true;
 		}


### PR DESCRIPTION
GetComponent<T> allows to use generic type parameters, which derived from Component
In that case "GetComponent called with non-Component"  should not be triggered
Fixes #71

#### Checklist
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md);
- [x] I have added tests that prove my fix is effective or that my feature works;

#### Short description of what this resolves:
UNT0014 triggers in cases with generic type parameters (with Component constraint), which is correct, that PR resolves this problem.

#### Changes proposed in this pull request:
- GetComponentIncorrectTypeAnalyzer now checks generic type parameters constraints and do not raise a warning if Component type constraint is found - https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/master/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
- Additional tests here - https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/master/src/Microsoft.Unity.Analyzers.Tests/GetComponentIncorrectTypeTests.cs, that covers such cases
