### PR TITLE
Add fxcop suppressions

### DIFF
--- a/doc/USP0013.md
+++ b/doc/USP0013.md
@@ -1,0 +1,26 @@
+# USP0013 Don't flag private fields with SerializeField or SerializeReference attributes as unused
+
+Private fields with the `SerializeField` or `SerializeReference` attributes should not be marked as unused by FxCop.
+
+## Suppressed Diagnostic ID
+
+CA1823 - Remove unused fields
+
+## Examples of code that produces a suppressed diagnostic
+```csharp
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+	[SerializeField]
+	private string someField = "default";
+}
+```
+
+## Why is the diagnostic reported?
+
+FxCop does not detect that the field is ever used within the project. Therefore, under normal circumstances, it would be reasonable to remove the unused code.
+
+## Why do we suppress this diagnostic?
+
+A field with the `SerializeField` or `SerializeReference` attributes are exposed and can be used in the Unity Inspector.

--- a/doc/USP0014.md
+++ b/doc/USP0014.md
@@ -1,0 +1,28 @@
+# USP0014 The Unity runtime invokes Unity messages
+
+Unity messages should not be flagged as candidates for static modifier.
+
+## Suppressed Diagnostic ID
+
+CA1822 - Mark members as static
+
+## Examples of code that produces a suppressed diagnostic
+```csharp
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+	void Update()
+	{
+		//Some code that does not access instance data
+	}
+}
+```
+
+## Why is the diagnostic reported?
+
+Members that do not access instance data or call instance methods can be marked as static for performance reasons.
+
+## Why do we suppress this diagnostic?
+
+Unity messages will not be processed if they are marked static.

--- a/doc/USP0015.md
+++ b/doc/USP0015.md
@@ -1,0 +1,28 @@
+# USP0015 The Unity runtime invokes Unity messages
+
+Unused parameters should not be removed from Unity messages.
+
+## Suppressed Diagnostic ID
+
+CA1801 - Remove the parameter or use it in the method body.
+
+## Examples of code that produces a suppressed diagnostic
+```csharp
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+	void OnCollisionEnter(Collision c)
+	{
+		// do stuff, but c remains unused
+	}
+}
+```
+
+## Why is the diagnostic reported?
+
+FxCop does not detect that you've used `c`, and under normal circumstances, it would be reasonable to remove the unused parameter.
+
+## Why do we suppress this diagnostic?
+
+FxCop doesn't realize this is a Unity message, and therefore has no way of determining that it needs to have a specific signature to function correctly.

--- a/doc/index.md
+++ b/doc/index.md
@@ -36,3 +36,6 @@ ID | Suppressed ID | Justification
 [USP0010](USP0010.md) | IDE0051 | Don't flag fields with the ContextMenuItem attribute as unused
 [USP0011](USP0011.md) | IDE0044 | Don't make fields with the ContextMenuItem attribute read-only
 [USP0012](USP0012.md) | IDE0051 | Don't flag private methods with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod attribute as unused.
+[USP0013](USP0013.md) | CA1823 | Don't flag private fields with SerializeField or SerializeReference attributes as unused
+[USP0014](USP0014.md) | CA1822 | The Unity runtime invokes Unity messages
+[USP0015](USP0015.md) | CA1801 | The Unity runtime invokes Unity messages

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -132,6 +132,17 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
+# CodeStyle/FxCop diagnostics that need review
+dotnet_diagnostic.CA1031.severity = none
+dotnet_diagnostic.CA1062.severity = none
+dotnet_diagnostic.CA1801.severity = none
+dotnet_diagnostic.CA1815.severity = none
+dotnet_diagnostic.CA1819.severity = none
+dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.CA2211.severity = none
+dotnet_diagnostic.IDE1006.severity = none
+dotnet_diagnostic.IDE0060.severity = none
+
 # C++ Files
 [*.{cpp,h,in}]
 curly_bracket_next_line = true

--- a/src/Microsoft.Unity.Analyzers.Tests/MessageFxCopSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/MessageFxCopSuppressorTests.cs
@@ -1,0 +1,57 @@
+﻿/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests
+{
+	public class MessageFxCopSuppressorTests : BaseSuppressorVerifierTest<MessageSuppressor>
+	{
+		// Only load FxCop analyzers for those tests
+		protected override SuppressorVerifierAnalyzers SuppressorVerifierAnalyzers => SuppressorVerifierAnalyzers.FxCop;
+
+		[Fact]
+		public async Task StaticMethodSuppressed()
+		{
+			const string test = @"
+using UnityEngine;
+
+public class TestScript : MonoBehaviour
+{
+    private void Start()
+    {
+    }
+}
+";
+
+			var suppressor = ExpectSuppressor(MessageSuppressor.MethodFxCopRule)
+				.WithLocation(6, 18);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+
+		[Fact]
+		public async Task UnusedParameterSuppressed()
+		{
+			const string test = @"
+using UnityEngine;
+
+public class TestScript : MonoBehaviour
+{
+    private void OnAnimatorIK(int layerIndex)
+    {
+        OnAnimatorIK(0);
+    }
+}
+";
+
+			var suppressor = ExpectSuppressor(MessageSuppressor.ParameterFxCopRule)
+				.WithLocation(6, 35);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers.Tests/MessageSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/MessageSuppressorTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.Unity.Analyzers.Tests
 {
-	public class UnusedMessageSuppressorTests : BaseSuppressorVerifierTest<UnusedMessageSuppressor>
+	public class MessageSuppressorTests : BaseSuppressorVerifierTest<MessageSuppressor>
 	{
 		[Fact]
 		public async Task UnusedMethodSuppressed()
@@ -24,7 +24,7 @@ public class TestScript : MonoBehaviour
 }
 ";
 
-			var suppressor = ExpectSuppressor(UnusedMessageSuppressor.MethodRule)
+			var suppressor = ExpectSuppressor(MessageSuppressor.MethodRule)
 				.WithLocation(6, 18);
 
 			await VerifyCSharpDiagnosticAsync(test, suppressor);
@@ -45,7 +45,7 @@ public class TestScript : MonoBehaviour
 }
 ";
 
-			var suppressor = ExpectSuppressor(UnusedMessageSuppressor.ParameterRule)
+			var suppressor = ExpectSuppressor(MessageSuppressor.ParameterRule)
 				.WithLocation(6, 35);
 
 			await VerifyCSharpDiagnosticAsync(test, suppressor);

--- a/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
+++ b/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-3.20177.13" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.0.0" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -23,6 +24,9 @@
 
   <ItemGroup>
     <None Include="$(PkgMicrosoft_CodeAnalysis_CSharp_CodeStyle)\analyzers\dotnet\cs\*.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>  
+    <None Include="$(PkgMicrosoft_CodeQuality_Analyzers)\analyzers\dotnet\cs\*.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>  
   </ItemGroup>

--- a/src/Microsoft.Unity.Analyzers.Tests/SerializeFieldFxCopSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/SerializeFieldFxCopSuppressorTests.cs
@@ -1,0 +1,36 @@
+﻿/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests
+{
+	public class SerializeFieldFxCopSuppressorTests : BaseSuppressorVerifierTest<SerializeFieldSuppressor>
+	{
+		// Only load FxCop analyzers for those tests
+		protected override SuppressorVerifierAnalyzers SuppressorVerifierAnalyzers => SuppressorVerifierAnalyzers.FxCop;
+
+		[Fact]
+		public async Task PrivateFieldWithAttributeUnusedSuppressed()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    [SerializeField]
+    string someField = ""default"";
+}
+";
+
+			var suppressor = ExpectSuppressor(SerializeFieldSuppressor.UnusedFxCopRule)
+				.WithLocation(7, 12);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/MessageSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/MessageSuppressor.cs
@@ -13,19 +13,29 @@ using Microsoft.Unity.Analyzers.Resources;
 namespace Microsoft.Unity.Analyzers
 {
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
-	public class UnusedMessageSuppressor : DiagnosticSuppressor
+	public class MessageSuppressor : DiagnosticSuppressor
 	{
 		internal static readonly SuppressionDescriptor MethodRule = new SuppressionDescriptor(
 			id: "USP0003",
 			suppressedDiagnosticId: "IDE0051",
-			justification: Strings.UnusedMessageSuppressorJustification);
+			justification: Strings.MessageSuppressorJustification);
+
+		internal static readonly SuppressionDescriptor MethodFxCopRule = new SuppressionDescriptor(
+			id: "USP0014",
+			suppressedDiagnosticId: "CA1822",
+			justification: Strings.MessageSuppressorJustification);
 
 		internal static readonly SuppressionDescriptor ParameterRule = new SuppressionDescriptor(
 			id: "USP0005",
 			suppressedDiagnosticId: "IDE0060",
-			justification: Strings.UnusedMessageSuppressorJustification);
+			justification: Strings.MessageSuppressorJustification);
 
-		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(MethodRule, ParameterRule);
+		internal static readonly SuppressionDescriptor ParameterFxCopRule = new SuppressionDescriptor(
+			id: "USP0015",
+			suppressedDiagnosticId: "CA1801",
+			justification: Strings.MessageSuppressorJustification);
+
+		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(MethodRule, MethodFxCopRule, ParameterRule, ParameterFxCopRule);
 
 		public override void ReportSuppressions(SuppressionAnalysisContext context)
 		{

--- a/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
+++ b/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
@@ -144,8 +144,7 @@ namespace Microsoft.Unity.Analyzers
 			if (!(invocation.Expression is MemberAccessExpressionSyntax maes))
 				return true;
 
-			var typeInvocationContext = model.GetTypeInfo(maes.ChildNodes().FirstOrDefault()).Type as INamedTypeSymbol;
-			if (typeInvocationContext == null)
+			if (!(model.GetTypeInfo(maes.ChildNodes().FirstOrDefault()).Type is INamedTypeSymbol typeInvocationContext))
 				return false;
 
 			var mdec = invocation

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -412,6 +412,15 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Unity runtime invokes Unity messages..
+        /// </summary>
+        internal static string MessageSuppressorJustification {
+            get {
+                return ResourceManager.GetString("MessageSuppressorJustification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Usage of nameof or direct call is preferred for type safety..
         /// </summary>
         internal static string MethodInvocationDiagnosticDescription {
@@ -714,15 +723,6 @@ namespace Microsoft.Unity.Analyzers.Resources {
         internal static string UnusedCoroutineReturnValueDiagnosticTitle {
             get {
                 return ResourceManager.GetString("UnusedCoroutineReturnValueDiagnosticTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The Unity runtime invokes Unity messages..
-        /// </summary>
-        internal static string UnusedMessageSuppressorJustification {
-            get {
-                return ResourceManager.GetString("UnusedMessageSuppressorJustification", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -264,7 +264,7 @@
   <data name="CreateScriptableObjectInstanceDiagnosticTitle" xml:space="preserve">
     <value>ScriptableObject instance creation</value>
   </data>
-  <data name="UnusedMessageSuppressorJustification" xml:space="preserve">
+  <data name="MessageSuppressorJustification" xml:space="preserve">
     <value>The Unity runtime invokes Unity messages.</value>
   </data>
   <data name="ReadonlySerializeFieldSuppressorJustification" xml:space="preserve">

--- a/src/Microsoft.Unity.Analyzers/SerializeFieldSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/SerializeFieldSuppressor.cs
@@ -25,12 +25,17 @@ namespace Microsoft.Unity.Analyzers
 			suppressedDiagnosticId: "IDE0051",
 			justification: Strings.UnusedSerializeFieldSuppressorJustification);
 
+		internal static readonly SuppressionDescriptor UnusedFxCopRule = new SuppressionDescriptor(
+			id: "USP0013",
+			suppressedDiagnosticId: "CA1823",
+			justification: Strings.UnusedSerializeFieldSuppressorJustification);
+
 		internal static readonly SuppressionDescriptor NeverAssignedRule = new SuppressionDescriptor(
 			id: "USP0007",
 			suppressedDiagnosticId: "CS0649",
 			justification: Strings.NeverAssignedSerializeFieldSuppressorJustification);
 
-		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(ReadonlyRule, UnusedRule, NeverAssignedRule);
+		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(ReadonlyRule, UnusedRule, UnusedFxCopRule, NeverAssignedRule);
 
 		public override void ReportSuppressions(SuppressionAnalysisContext context)
 		{


### PR DESCRIPTION
Fixes #81 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Suppress additionnal rules for FxCop analyzers:
- `CA1801`: Remove the parameter or use it in the method body.
- `CA1822`: Mark members as static.
- `CA1823`: Remove unused fields.

#### Changes proposed in this pull request:
Reuse existing detection mechanisms for MonoBehaviours/Messages/Serialized fields