### PR TITLE
Add MenuItem to the ContextMenuSuppressor

### DIFF
--- a/doc/USP0009.md
+++ b/doc/USP0009.md
@@ -1,6 +1,6 @@
 # USP0009 Don't flag methods with the ContextMenu attribute or referenced by a field with the ContextMenuItem attribute as unused
 
-Methods decorated with the `ContextMenu` attribute, or referenced by a field with `ContextMenuItem` are not unused.
+Methods decorated with `ContextMenu`/`MenuItem` attribute, or referenced by a field with `ContextMenuItem` are not unused.
 
 ## Suppressed Diagnostic ID
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -32,7 +32,7 @@ ID | Suppressed ID | Justification
 [USP0006](USP0006.md) | IDE0051 | Don't flag private fields with SerializeField or SerializeReference attributes as unused
 [USP0007](USP0007.md) | CS0649 | Don't flag fields with SerializeField or SerializeReference attributes as never assigned
 [USP0008](USP0008.md) | IDE0051 | Don't flag private methods used with Invoke/InvokeRepeating or StartCoroutine/StopCoroutine as unused
-[USP0009](USP0009.md) | IDE0051 | Don't flag methods with the ContextMenu attribute or referenced by a field with the ContextMenuItem attribute as unused.
+[USP0009](USP0009.md) | IDE0051 | Don't flag methods with MenuItem/ContextMenu attribute or referenced by a field with the ContextMenuItem attribute as unused.
 [USP0010](USP0010.md) | IDE0051 | Don't flag fields with the ContextMenuItem attribute as unused
 [USP0011](USP0011.md) | IDE0044 | Don't make fields with the ContextMenuItem attribute read-only
 [USP0012](USP0012.md) | IDE0051 | Don't flag private methods with InitializeOnLoadMethod or RuntimeInitializeOnLoadMethod attribute as unused.

--- a/src/Microsoft.Unity.Analyzers.Tests/ContextMenuSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ContextMenuSuppressorTests.cs
@@ -4,7 +4,6 @@
  *-------------------------------------------------------------------------------------------*/
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace Microsoft.Unity.Analyzers.Tests
@@ -27,6 +26,27 @@ class Menu : MonoBehaviour
 
 			var suppressor = ExpectSuppressor(ContextMenuSuppressor.ContextMenuRule)
 				.WithLocation(7, 18);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+
+		[Fact]
+		public async Task MenuItemSuppressed()
+		{
+			const string test = @"
+using UnityEditor;
+using UnityEngine;
+
+class Menu : MonoBehaviour
+{
+    [MenuItem(""Tools/Project Reference Generator"")]
+    private static void MenuItemMethod()
+    {
+    }
+}";
+
+			var suppressor = ExpectSuppressor(ContextMenuSuppressor.ContextMenuRule)
+				.WithLocation(8, 25);
 
 			await VerifyCSharpDiagnosticAsync(test, suppressor);
 		}

--- a/src/Microsoft.Unity.Analyzers/ContextMenuSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/ContextMenuSuppressor.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Unity.Analyzers
 			switch (symbol)
 			{
 				case IMethodSymbol methodSymbol:
-					if (methodSymbol.GetAttributes().Any(a => a.AttributeClass.Matches(typeof(UnityEngine.ContextMenu))))
+					if (methodSymbol.GetAttributes().Any(a => a.AttributeClass.Matches(typeof(UnityEngine.ContextMenu)) || a.AttributeClass.Matches(typeof(UnityEditor.MenuItem))))
 						return true;
 					if (IsReferencedByContextMenuItem(methodSymbol, containingType))
 						return true;

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -727,7 +727,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Don&apos;t flag methods with the ContextMenu attribute or referenced by a field with the ContextMenuItem attribute as unused..
+        ///   Looks up a localized string similar to Don&apos;t flag methods with MenuItem/ContextMenu attribute or referenced by a field with the ContextMenuItem attribute as unused..
         /// </summary>
         internal static string UnusedMethodContextMenuSuppressorJustification {
             get {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -292,7 +292,7 @@
     <value>Unused Unity Coroutine</value>
   </data>
   <data name="UnusedMethodContextMenuSuppressorJustification" xml:space="preserve">
-    <value>Don't flag methods with the ContextMenu attribute or referenced by a field with the ContextMenuItem attribute as unused.</value>
+    <value>Don't flag methods with MenuItem/ContextMenu attribute or referenced by a field with the ContextMenuItem attribute as unused.</value>
   </data>
   <data name="ReadonlyContextMenuItemJustification" xml:space="preserve">
     <value>Don't set fields with a ContextMenuItem attribute as readonly.</value>

--- a/src/Microsoft.Unity.Analyzers/UnityStubs.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityStubs.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Unity.Analyzers;
-using Microsoft.Unity.Analyzers.Resources;
 
 namespace UnityEngine
 {
@@ -365,6 +364,10 @@ namespace UnityEditor
 	}
 
 	class InitializeOnLoadMethodAttribute : System.Attribute
+	{
+	}
+
+	class MenuItem : System.Attribute
 	{
 	}
 }


### PR DESCRIPTION
Fixes #84 

#### Checklist
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Suppress IDE0051 for methods decorated with `MenuItem` attribute.

#### Changes proposed in this pull request:
Update the `ContextMenuSuppressor` rule `USP0009` to detect both `ContextMenu` and `MenuItem` attributes.
