### PR TITLE
Fix USP0001 and USP0002 not working with extra parentheses or method arguments

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingSuppressorTests.cs
@@ -57,6 +57,35 @@ class Camera : MonoBehaviour
 		}
 
 		[Fact]
+		public async Task NullCoalescingMethodArgumentSuppressed()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public Transform a = null;
+    public Transform b = null;
+
+	public Transform Method(Transform o)
+    {
+        return o;
+    }
+
+    public Transform NC()
+    {
+        return Method((a != null) ? a : b);
+    }
+}";
+
+			var suppressor = ExpectSuppressor(UnityObjectNullHandlingSuppressor.NullCoalescingRule)
+				.WithLocation(16, 23);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+
+
+		[Fact]
 		public async Task NullPropagationSuppressed()
 		{
 			const string test = @"
@@ -95,6 +124,30 @@ class Camera : MonoBehaviour
 
 			await VerifyCSharpDiagnosticAsync(test, suppressor);
 		}
+
+		[Fact]
+		public async Task NullPropagationMethodArgumentSuppressed()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public void Method(object o) {
+    }
+
+    public void NP(Transform o)
+    {
+        Method(((o == null)) ? null : o.ToString());
+    }
+}";
+
+			var suppressor = ExpectSuppressor(UnityObjectNullHandlingSuppressor.NullPropagationRule)
+				.WithLocation(11, 16);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+
 
 	}
 }

--- a/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingSuppressorTests.cs
@@ -34,6 +34,29 @@ class Camera : MonoBehaviour
 		}
 
 		[Fact]
+		public async Task NullCoalescingParenthesisSuppressed()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public Transform a = null;
+    public Transform b = null;
+
+    public Transform NC()
+    {
+        return (a != null) ? a : b;
+    }
+}";
+
+			var suppressor = ExpectSuppressor(UnityObjectNullHandlingSuppressor.NullCoalescingRule)
+				.WithLocation(11, 16);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+
+		[Fact]
 		public async Task NullPropagationSuppressed()
 		{
 			const string test = @"
@@ -52,5 +75,26 @@ class Camera : MonoBehaviour
 
 			await VerifyCSharpDiagnosticAsync(test, suppressor);
 		}
+
+		[Fact]
+		public async Task NullPropagationParenthesisSuppressed()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public void NP(Transform o)
+    {
+        var v = ((o == null)) ? null : o.ToString();
+    }
+}";
+
+			var suppressor = ExpectSuppressor(UnityObjectNullHandlingSuppressor.NullPropagationRule)
+				.WithLocation(8, 17);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+
 	}
 }

--- a/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingSuppressorTests.cs
@@ -67,7 +67,7 @@ class Camera : MonoBehaviour
     public Transform a = null;
     public Transform b = null;
 
-	public Transform Method(Transform o)
+    public Transform Method(Transform o)
     {
         return o;
     }

--- a/src/Microsoft.Unity.Analyzers/UnityObjectNullHandling.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityObjectNullHandling.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Unity.Analyzers
 		{
 			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-			if (!(root.FindNode(context.Span) is BinaryExpressionSyntax coalescing))
+			if (!(root?.FindNode(context.Span) is BinaryExpressionSyntax coalescing))
 				return;
 
 			// We do not want to fix expressions with possible side effects such as `Foo() ?? bar`

--- a/src/Microsoft.Unity.Analyzers/UnityObjectNullHandling.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityObjectNullHandling.cs
@@ -154,18 +154,21 @@ namespace Microsoft.Unity.Analyzers
 			if (node == null)
 				return;
 
-			if (!(node is ConditionalExpressionSyntax cex))
-				return;
-
-			AnalyzeConditionExpression(diagnostic, context, cex.Condition);
+			AnalyzeNode(diagnostic, context, node);
 		}
 
-		private static void AnalyzeConditionExpression(Diagnostic diagnostic, SuppressionAnalysisContext context, ExpressionSyntax expression)
+		private static void AnalyzeNode(Diagnostic diagnostic, SuppressionAnalysisContext context, SyntaxNode node)
 		{
-			switch (expression.Kind())
+			switch (node.Kind())
 			{
+				case SyntaxKind.Argument:
+					AnalyzeNode(diagnostic, context, ((ArgumentSyntax)node).Expression);
+					return;
 				case SyntaxKind.ParenthesizedExpression:
-					AnalyzeConditionExpression(diagnostic, context, ((ParenthesizedExpressionSyntax)expression).Expression);
+					AnalyzeNode(diagnostic, context, ((ParenthesizedExpressionSyntax)node).Expression);
+					return;
+				case SyntaxKind.ConditionalExpression:
+					AnalyzeNode(diagnostic, context, ((ConditionalExpressionSyntax)node).Condition);
 					return;
 				case SyntaxKind.EqualsExpression:
 				case SyntaxKind.NotEqualsExpression:
@@ -174,11 +177,11 @@ namespace Microsoft.Unity.Analyzers
 					return;
 			}
 
-			var binary = (BinaryExpressionSyntax)expression;
+			var binary = (BinaryExpressionSyntax)node;
 			if (!binary.Right.IsKind(SyntaxKind.NullLiteralExpression))
 				return;
 
-			var model = context.GetSemanticModel(expression.SyntaxTree);
+			var model = context.GetSemanticModel(node.SyntaxTree);
 			if (model == null)
 				return;
 


### PR DESCRIPTION
Fixes #88 

#### Checklist
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
- Fix parentheses handling for both [USP0001](https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/master/doc/USP0001.md) and [USP0002](https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/master/doc/USP0002.md)
- Fix detection when the conditional expression is passed as an argument