### PR TITLE
Fixes #93, typo with InitializeOnLoadStaticCtorDiagnosticMessageFormat

### DIFF
--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Class &quot;{0}&quot; decorated with the InitializeOnLoad attribute is missing a static conductor..
+        ///   Looks up a localized string similar to Class &quot;{0}&quot; decorated with the InitializeOnLoad attribute is missing a static constructor..
         /// </summary>
         internal static string InitializeOnLoadStaticCtorDiagnosticMessageFormat {
             get {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -193,7 +193,7 @@
     <value>Provide a static constructor when applying the InitializeOnLoad attribute to a class. This will call it when the editor launches.</value>
   </data>
   <data name="InitializeOnLoadStaticCtorDiagnosticMessageFormat" xml:space="preserve">
-    <value>Class "{0}" decorated with the InitializeOnLoad attribute is missing a static conductor.</value>
+    <value>Class "{0}" decorated with the InitializeOnLoad attribute is missing a static constructor.</value>
   </data>
   <data name="InitializeOnLoadStaticCtorDiagnosticTitle" xml:space="preserve">
     <value>Missing static constructor with InitializeOnLoad</value>


### PR DESCRIPTION
Fixes #93

#### Checklist
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;

#### Short description of what this resolves:
Typo in the `InitializeOnLoadStaticCtorDiagnosticMessageFormat` resource entry.
