### PR TITLE
Nullable reference types suppressor

### DIFF
--- a/doc/USP0016.md
+++ b/doc/USP0016.md
@@ -1,0 +1,57 @@
+# USP0016 Suppress NullableReferenceTypes warning (CS8618) for fields and properties that cannot be initialized and check for assignment to these in Unity's initialization methods or inspector
+
+Initialization of types inheriting from UnityEngine.Object is not supported and will result in errors.
+
+## Suppressed Diagnostic ID
+
+CS8618  -  Non-nullable field '{0}' is uninitialized. Consider declaring the field as nullable.
+
+## Examples of code that produces a suppressed diagnostic
+```csharp
+using UnityEngine;
+
+public class Test : Monobehaviour
+{
+	private GameObject field;
+	
+	private void Start()
+	{
+		Initialize();
+	}
+	
+	private void Initialize()
+	{
+		field = new GameObject();
+	}
+}
+```
+and:
+```csharp
+using UnityEngine;
+
+public class Test : Monobehaviour
+{
+	public GameObject Property { get; set; }
+	
+	private void Awake()
+	{
+		Property = GameObject.Find("Player");
+	}
+}
+```
+and:
+```csharp
+using UnityEngine;
+
+public class Test : Monobehaviour
+{
+	[SerializeField] private UnityEngine.Object serializedField;
+}
+```
+## Why is the diagnostic reported?
+
+The IDE cannot detect that types inheriting 'UnityEngine.Object' cannot be initialized.
+
+## Why do we suppress this diagnsotic?
+
+Fields or properties of such types cannot be initialized next to their declaration but can be assigned to in Unity's initialization methods such as 'OnEnable()', 'Awake()', and 'Start()' or all methods called by these, or the inspector.

--- a/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
@@ -4,7 +4,6 @@
  *-------------------------------------------------------------------------------------------*/
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Xunit;
 
 namespace Microsoft.Unity.Analyzers.Tests

--- a/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
@@ -1,0 +1,79 @@
+﻿/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests
+{
+	public class NullableReferenceTypesSuppressorTest : BaseSuppressorVerifierTest<NullableReferenceTypesSuppressor>
+	{
+		[Fact]
+		public async Task NullableReferenceTypesSuppressed()
+		{
+			const string test =
+@"
+#nullable enable
+
+using UnityEngine;
+
+public class TestScript : MonoBehaviour
+{
+	private UnityEngine.Object field1;
+	private GameObject field2;
+	public UnityEngine.Object field3;
+
+	public UnityEngine.Object Property1 { get; set; }
+	public UnityEngine.Object Property2 { get { return property2Field; } set { property2Field = value; } }
+	private UnityEngine.Object property2Field;
+
+	[SerializeField] private GameObject serializedField;
+
+	public static GameObject staticField;
+
+	[HideInInspector] public GameObject hiddenField;
+	[HideInInspector] public GameObject hiddenField2;
+
+    private void Start()
+    {
+		field1 = new UnityEngine.Object();
+		InitializeField2();
+
+		Property1 = new UnityEngine.Object();
+		Property2 = new UnityEngine.Object();
+
+		staticField = new GameObject();
+
+		hiddenField2 = new GameObject();
+    }
+
+	private void InitializeField2()
+	{
+		field2 = new GameObject();
+	}
+}
+";
+
+			DiagnosticResult[] suppressor =
+			{
+				ExpectSuppressor(NullableReferenceTypesSuppressor.NullableRule).WithLocation(8, 29), //field1
+				ExpectSuppressor(NullableReferenceTypesSuppressor.NullableRule).WithLocation(9, 21), //field2
+				ExpectSuppressor(NullableReferenceTypesSuppressor.NullableRule).WithLocation(10, 28), //field3
+				ExpectSuppressor(NullableReferenceTypesSuppressor.NullableRule).WithLocation(12, 28), //Property1
+				ExpectSuppressor(NullableReferenceTypesSuppressor.NullableRule).WithLocation(14, 29), //property2Field
+				ExpectSuppressor(NullableReferenceTypesSuppressor.NullableRule).WithLocation(16, 38), //serializedField
+				DiagnosticResult.CompilerWarning("CS0169").WithMessage("The field 'TestScript.serializedField' is never used").WithLocation(16, 38), //warning is not part of this analyzer
+				ExpectSuppressor(NullableReferenceTypesSuppressor.NullableRule).WithLocation(18, 27), //staticField
+				//ExpectDiagnostic().WithMessage("Non-nullable field 'hiddenField' is uninitialized. Consider declaring the field as nullable.").WithLocation(20, 38), //HOW TO WORK WITH SYSTEM DIAGNOSTICS?
+				DiagnosticResult.CompilerWarning("CS8618").WithMessage("Non-nullable field 'hiddenField' is uninitialized. Consider declaring the field as nullable.")
+					.WithLocation(20, 38), //should throw on public fields that are not shown in the inspector
+				ExpectSuppressor(NullableReferenceTypesSuppressor.NullableRule).WithLocation(21, 38)
+		};
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/NullableReferenceTypesSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/NullableReferenceTypesSuppressor.cs
@@ -1,0 +1,166 @@
+﻿/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+//#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Unity.Analyzers.Resources;
+
+namespace Microsoft.Unity.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class NullableReferenceTypesSuppressor : DiagnosticSuppressor
+	{
+		private const string NULLABLE_WARNING = "CS8618";
+
+		internal static SuppressionDescriptor NullableRule { get; } = new SuppressionDescriptor("USP0016", NULLABLE_WARNING, Strings.NullableReferenceTypesSuppressorJustification);
+
+		//this, rather than IA => IA.Create(), should be faster because it doesn't allocate a new IA every time the value is needed
+		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; } = ImmutableArray.Create(NullableRule);
+
+		public override void ReportSuppressions(SuppressionAnalysisContext context)
+		{
+			foreach (Diagnostic diagnostic in context.ReportedDiagnostics.Where(diagnostic => diagnostic.Id == NULLABLE_WARNING))
+			{
+				SyntaxNode root = diagnostic.Location.SourceTree.GetRoot();
+				SyntaxNode location = root.FindNode(diagnostic.Location.SourceSpan);
+
+				//does the inspected class inherit from Monobehaviour?
+				if (!location.FirstAncestorOrSelf<ClassDeclarationSyntax>()?.BaseList?.ChildNodes().Any(node => GetSymbol(diagnostic.Location.SourceTree, ((BaseTypeSyntax)node).Type, context.Compilation).Extends(typeof(UnityEngine.MonoBehaviour))) ?? true)
+				{
+					continue;
+				}
+
+				PropertyDeclarationSyntax propertyDeclaration = location.FirstAncestorOrSelf<PropertyDeclarationSyntax>();
+
+				if (!(propertyDeclaration is null))
+				{
+					AnalyzeProperties(propertyDeclaration, diagnostic, context, root);
+					continue;
+				}
+
+				if (location is VariableDeclaratorSyntax fieldDeclaration)
+				{
+					AnalyzeFields(fieldDeclaration, diagnostic, context, root);
+					continue;
+				}
+
+				//TODO handle nullable warnings for constructors => diagnostic location is now on constructor
+				//TODO handle other Unity objects that cannot be initialized => e.g. Unity's new Input system
+				//TODO annotate nullability once this project actively uses C# 8.0
+			}
+		}
+
+		private static void AnalyzeFields(VariableDeclaratorSyntax declarator, Diagnostic diagnostic, SuppressionAnalysisContext context, SyntaxNode root)
+		{
+			FieldDeclarationSyntax declarationSyntax = declarator.FirstAncestorOrSelf<FieldDeclarationSyntax>();
+
+			//suppress for fields that are not private and not static => statics cannot be set in editor and are not shown in the inspector and cannot be set there
+			if (!declarationSyntax.Modifiers.Any(modifier => modifier.Text == "private" || modifier.Text == "static")
+				&& !declarationSyntax.AttributeLists.Any(attributeList => attributeList.Attributes.Any(attribute => attribute.Name.ToString() == "HideInInspector")))
+			{
+					context.ReportSuppression(Suppression.Create(NullableRule, diagnostic));
+					return;
+			}
+
+			//check for serializefield attribute => variable could be set in editor
+			if (declarationSyntax.AttributeLists.Any(attributeList => attributeList.Attributes.Any(attribute => attribute.Name.ToString() == "SerializeField")))
+			{
+				context.ReportSuppression(Suppression.Create(NullableRule, diagnostic));
+				return;
+			}
+
+			ITypeSymbol symbol = GetSymbol(diagnostic.Location.SourceTree, declarationSyntax.Declaration.Type, context.Compilation);
+
+			if (symbol.Extends(typeof(UnityEngine.Object)))
+			{
+				IEnumerable<SyntaxNode> methodBodies = MethodBodies(root);
+
+				//check for valid assignments
+				if (IsAssignedTo(declarator.Identifier.Text, methodBodies))
+				{
+					context.ReportSuppression(Suppression.Create(NullableRule, diagnostic));
+					return;
+				}
+
+				//check for existence of this variable in any assigned property
+				foreach (string variable in AssignedProperties(root, methodBodies))
+				{
+					if (variable == declarator.Identifier.Text)
+					{
+						context.ReportSuppression(Suppression.Create(NullableRule, diagnostic));
+					}
+				}
+			}
+		}
+
+		private static void AnalyzeProperties(PropertyDeclarationSyntax declarationSyntax, Diagnostic diagnostic, SuppressionAnalysisContext context, SyntaxNode root)
+		{
+			ITypeSymbol symbol = GetSymbol(diagnostic.Location.SourceTree, declarationSyntax.Type, context.Compilation);
+
+			if (!symbol.Extends(typeof(UnityEngine.Object)))
+			{
+				return;
+			}
+
+			//check for valid assignments
+			if (IsAssignedTo(declarationSyntax.Identifier.Text, MethodBodies(root)))
+			{
+				context.ReportSuppression(Suppression.Create(NullableRule, diagnostic));
+			}
+		}
+
+		private static ITypeSymbol GetSymbol(SyntaxTree tree, TypeSyntax type, Compilation compilation)
+		{
+			return (ITypeSymbol)compilation.GetSemanticModel(tree).GetSymbolInfo(type).Symbol;
+		}
+
+		//analyze if a property is assigned inside a methodbody
+		private static bool IsAssignedTo(string identifier, IEnumerable<SyntaxNode> methodBodies)
+		{
+			return methodBodies.Select(node => node.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+			.Where(assignmentExpression => assignmentExpression.Left.ToString() == identifier && assignmentExpression.Right.ToString() != "null")
+			.FirstOrDefault())
+				.Any(expression => !(expression is null));
+		}
+
+		//get all method bodies from all unity methods and methods called by them
+		private static IEnumerable<SyntaxNode> MethodBodies(SyntaxNode root)
+		{
+			IEnumerable<MethodDeclarationSyntax> methods = root.DescendantNodes().OfType<MethodDeclarationSyntax>();
+			IEnumerable<SyntaxNode> methodBodies = Enumerable.Empty<SyntaxNode>();
+
+			foreach (MethodDeclarationSyntax methodSyntax in methods.Where(method => method.Identifier.Text == "Start" || method.Identifier.Text == "Awake" || method.Identifier.Text == "OnEnable"))
+			{
+				methodBodies = methodBodies.Concat(methods
+					.Where(syntax => methodSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>()
+					.Any(invocationSyntax => invocationSyntax.Expression.ToString() == syntax.Identifier.Text))
+					.Concat(new[] { methodSyntax })
+					.Select(method => method.Body ?? (SyntaxNode)method.ExpressionBody));
+			}
+
+			return methodBodies;
+		}
+
+		//get all explicit backingfields of assigned properties
+		private static IEnumerable<string> AssignedProperties(SyntaxNode root, IEnumerable<SyntaxNode> methodBodies)
+		{
+			return root.DescendantNodes().OfType<PropertyDeclarationSyntax>()
+				.Where(property => property.AccessorList.Accessors.Any(accessor => accessor.Keyword.Text == "set" && IsAssignedTo(property.Identifier.Text, methodBodies)))
+				.SelectMany(syntax => syntax.AccessorList.Accessors
+					.Select(accessor => accessor.Body ?? (SyntaxNode)accessor.ExpressionBody))
+					.Where(node => !(node is null))
+				.SelectMany(body => body.DescendantNodes().OfType<AssignmentExpressionSyntax>()
+					.Select(assignment => assignment.Left.ToString()));
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/NullableReferenceTypesSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/NullableReferenceTypesSuppressor.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Unity.Analyzers
 			FieldDeclarationSyntax declarationSyntax = declarator.FirstAncestorOrSelf<FieldDeclarationSyntax>();
 
 			//suppress for fields that are not private and not static => statics cannot be set in editor and are not shown in the inspector and cannot be set there
-			if (!declarationSyntax.Modifiers.Any(modifier => modifier.Text == "private" || modifier.Text == "static")
+			if (!declarationSyntax.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.PrivateKeyword) || modifier.IsKind(SyntaxKind.StaticKeyword))
 				&& !declarationSyntax.AttributeLists.Any(attributeList => attributeList.Attributes.Any(attribute => attribute.Name.ToString() == "HideInInspector")))
 			{
 					context.ReportSuppression(Suppression.Create(NullableRule, diagnostic));

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -511,6 +511,15 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Objects deriving from &apos;UnityEngine.Object&apos; cannot be initialized..
+        /// </summary>
+        internal static string NullableReferenceTypesSuppressorJustification {
+            get {
+                return ResourceManager.GetString("NullableReferenceTypesSuppressorJustification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Don&apos;t set fields with a ContextMenuItem attribute as readonly..
         /// </summary>
         internal static string ReadonlyContextMenuItemJustification {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -364,4 +364,7 @@
   <data name="SetPixelsMethodUsageDiagnosticTitle" xml:space="preserve">
     <value>SetPixels invocation is slow</value>
   </data>
+  <data name="NullableReferenceTypesSuppressorJustification" xml:space="preserve">
+    <value>Objects deriving from 'UnityEngine.Object' cannot be initialized.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes [#99](https://github.com/microsoft/Microsoft.Unity.Analyzers/issues/99)

#### Checklist
- [x] I have read the [Contribution Guide](https://github.com/CONTRIBUTING.md)

- [x] There is an approved issue describing the change when contributing a new analyzer or suppressor

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

Suppresses CS8618 warnings for fields and properties that inherit UnityEngine.Object and are assigned to in Unity's initialization methods or the inspector.

#### TODO
- [ ] Handle CS8618 warnings on constructors

- [ ] Suppress CS8618 for other non-initializable Unity objects e.g. Unity's new input system

- [ ] annotate nullability once this project natively uses C# 8.0 or above
