### PR TITLE
Add AssetPostprocessor members to the list of known messages

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/MessageSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/MessageSuppressorTests.cs
@@ -11,6 +11,29 @@ namespace Microsoft.Unity.Analyzers.Tests
 	public class MessageSuppressorTests : BaseSuppressorVerifierTest<MessageSuppressor>
 	{
 		[Fact]
+		public async Task UnusedStaticMethodAndParametersSuppressed()
+		{
+			const string test = @"
+using UnityEditor;
+
+class Processor : AssetPostprocessor
+{
+    private static string OnGeneratedCSProject(string path, string content)
+    {
+        return null;
+    }
+}";
+
+			var suppressors = new [] {
+				ExpectSuppressor(MessageSuppressor.MethodRule).WithLocation(6, 27),
+				ExpectSuppressor(MessageSuppressor.ParameterRule).WithLocation(6, 55),
+				ExpectSuppressor(MessageSuppressor.ParameterRule).WithLocation(6, 68),
+			};
+
+			await VerifyCSharpDiagnosticAsync(test, suppressors);
+		}
+
+		[Fact]
 		public async Task UnusedMethodSuppressed()
 		{
 			const string test = @"

--- a/src/Microsoft.Unity.Analyzers/ScriptInfo.cs
+++ b/src/Microsoft.Unity.Analyzers/ScriptInfo.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Unity.Analyzers
 {
 	internal class ScriptInfo
 	{
-		private static readonly Type[] Types = { typeof(UnityEngine.Networking.NetworkBehaviour), typeof(UnityEngine.StateMachineBehaviour), typeof(UnityEngine.EventSystems.UIBehaviour), typeof(UnityEditor.ScriptableWizard), typeof(UnityEditor.EditorWindow), typeof(UnityEditor.Editor), typeof(UnityEngine.ScriptableObject), typeof(UnityEngine.MonoBehaviour), };
+		private static readonly Type[] Types = { typeof(UnityEngine.Networking.NetworkBehaviour), typeof(UnityEngine.StateMachineBehaviour), typeof(UnityEngine.EventSystems.UIBehaviour), typeof(UnityEditor.ScriptableWizard), typeof(UnityEditor.EditorWindow), typeof(UnityEditor.Editor), typeof(UnityEngine.ScriptableObject), typeof(UnityEngine.MonoBehaviour), typeof(UnityEditor.AssetPostprocessor) };
 
 		private readonly ITypeSymbol _symbol;
 		private readonly Type _metadata;

--- a/src/Microsoft.Unity.Analyzers/UnityStubs.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityStubs.cs
@@ -95,6 +95,30 @@ namespace UnityEngine
 	{
 	}
 
+	class Material
+	{
+	}
+
+	class Renderer
+	{
+	}
+
+	class AnimationClip
+	{
+	}
+
+	class AudioClip
+	{
+	}
+
+	class Cubemap
+	{
+	}
+
+	class Sprite
+	{
+	}
+
 	class ScriptableObject
 	{
 		void Awake() { }
@@ -328,10 +352,18 @@ namespace UnityEngine.UIElements
 	}
 }
 
+namespace UnityEditor.AssetImporters
+{
+	class MaterialDescription
+	{
+	}
+}
+
 namespace UnityEditor
 {
 	using UnityEngine;
 	using UnityEngine.UIElements;
+	using AssetImporters;
 
 	class Editor : ScriptableObject
 	{
@@ -371,4 +403,40 @@ namespace UnityEditor
 	class MenuItem : System.Attribute
 	{
 	}
+
+	class EditorCurveBinding
+	{
+	}
+
+	class AssetPostprocessor
+	{
+		void OnAssignMaterialModel(Material material, Renderer renderer) { }
+		void OnPostprocessAnimation(GameObject root, AnimationClip clip) { }
+		void OnPostprocessAssetbundleNameChanged(string assetPath, string previousAssetBundleName, string newAssetBundleName) { }
+		void OnPostprocessAudio(AudioClip clip) { }
+		void OnPostprocessCubemap(Cubemap texture) { }
+		void OnPostprocessGameObjectWithAnimatedUserProperties(GameObject gameObject, EditorCurveBinding[] bindings) { }
+		void OnPostprocessGameObjectWithUserProperties(GameObject gameObject, string[] propNames, System.Object[] values) { }
+		void OnPostprocessMaterial(Material material) { }
+		void OnPostprocessMeshHierarchy(GameObject root) { }
+		void OnPostprocessModel(GameObject gameObject) { }
+		void OnPostprocessSpeedTree(GameObject gameobject) { }
+		void OnPostProcessSprites(Texture2D texture, Sprite[] sprites) { }
+		void OnPostprocessTexture(Texture2D texture) { }
+
+		void OnPreprocessAnimation() { }
+		void OnPreprocessAsset() { }
+		void OnPreprocessAudio() { }
+		void OnPreprocessMaterialDescription(MaterialDescription description, Material material, AnimationClip[] materialAnimation) { }
+		void OnPreprocessModel() { }
+		void OnPreprocessSpeedTree() { }
+		void OnPreprocessTexture() { }
+
+        // undocumented static methods
+		static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths) { }
+		static bool OnPreGeneratingCSProjectFiles() { return false; }
+		static string OnGeneratedSlnSolution(string path, string content) { return null; }
+		static string OnGeneratedCSProject(string path, string content) { return null; }
+	}
+
 }


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #85 

#### Checklist
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Add AssetPostprocessor members to the list of well known messages, so we can benefit from all the related suppressors.