### PR TITLE
Bump Unity version to 2019.4.8f1 LTS

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -27,12 +27,12 @@ jobs:
       id: cache-unity
       uses: actions/cache@v1
       with:
-        key: ${{ runner.os }}-unitycache-2019.4.1f1
+        key: ${{ runner.os }}-unitycache-2019.4.8f1
         path: UnityCache
 
-    - name: Download Unity 2019.4.1f1 LTS
+    - name: Download Unity 2019.4.8f1 LTS
       if: steps.cache-unity.outputs.cache-hit != 'true'
-      run: curl -o ./unity.pkg -k https://download.unity3d.com/download_unity/e6c045e14e4e/MacEditorInstaller/Unity.pkg
+      run: curl -o ./unity.pkg -k https://download.unity3d.com/download_unity/60781d942082/MacEditorInstaller/Unity.pkg
 
     - name: Install Unity
       if: steps.cache-unity.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -27,12 +27,12 @@ jobs:
       id: cache-unity
       uses: actions/cache@v1
       with:
-        key: ${{ runner.os }}-unitycache-2019.4.1f1
+        key: ${{ runner.os }}-unitycache-2019.4.8f1
         path: UnityCache
       
-    - name: Download Unity 2019.4.1f1 LTS
+    - name: Download Unity 2019.4.8f1 LTS
       if: steps.cache-unity.outputs.cache-hit != 'true'
-      run: bitsadmin /TRANSFER unity /DOWNLOAD /PRIORITY foreground "https://download.unity3d.com/download_unity/e6c045e14e4e/Windows64EditorInstaller/UnitySetup64-2019.4.1f1.exe" "%CD%\unitysetup.exe"
+      run: bitsadmin /TRANSFER unity /DOWNLOAD /PRIORITY foreground "https://download.unity3d.com/download_unity/60781d942082/Windows64EditorInstaller/UnitySetup64-2019.4.8f1.exe" "%CD%\unitysetup.exe"
       shell: cmd
       
     - name: Install Unity


### PR DESCRIPTION
#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;

#### Short description of what this resolves:
Bump Unity version to 2019.4.8f1 LTS, used by the test infrastructure