### PR TITLE
Extend UNT0010 to all components

### DIFF
--- a/doc/UNT0010.md
+++ b/doc/UNT0010.md
@@ -1,6 +1,6 @@
-# UNT0010 MonoBehaviour instance creation
+# UNT0010 Component instance creation
 
-Use AddComponent() to create MonoBehaviours. A MonoBehaviour component needs to be attached to a GameObject.
+Use AddComponent() to create components. A component needs to be attached to a GameObject.
 
 ## Examples of patterns that are flagged by this analyzer
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -11,7 +11,7 @@ ID | Title | Category
 [UNT0007](UNT0007.md) | Null coalescing on Unity objects | Correctness
 [UNT0008](UNT0008.md) | Null propagation on Unity objects | Correctness
 [UNT0009](UNT0009.md) | Missing static constructor with InitializeOnLoad | Correctness
-[UNT0010](UNT0010.md) | MonoBehaviour instance creation | Type Safety
+[UNT0010](UNT0010.md) | Component instance creation | Type Safety
 [UNT0011](UNT0011.md) | ScriptableObject instance creation | Type Safety
 [UNT0012](UNT0012.md) | Unused coroutine return value | Correctness
 [UNT0013](UNT0013.md) | Invalid or redundant SerializeField attribute | Correctness

--- a/src/Microsoft.Unity.Analyzers.Tests/CreateInstanceTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/CreateInstanceTests.cs
@@ -10,6 +10,44 @@ namespace Microsoft.Unity.Analyzers.Tests
 {
 	public class CreateInstanceTests : BaseCodeFixVerifierTest<CreateInstanceAnalyzer, CreateInstanceCodeFix>
 	{
+
+		[Fact]
+		public async Task CreateComponentInstance()
+		{
+			const string test = @"
+using UnityEngine;
+
+class Foo : Component { }
+
+class Camera : MonoBehaviour
+{
+    public void Update() {
+        Foo foo = new Foo();
+    }
+}
+";
+
+			var diagnostic = ExpectDiagnostic(CreateInstanceAnalyzer.ComponentId)
+				.WithLocation(9, 19)
+				.WithArguments("Foo");
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+			const string fixedTest = @"
+using UnityEngine;
+
+class Foo : Component { }
+
+class Camera : MonoBehaviour
+{
+    public void Update() {
+        Foo foo = gameObject.AddComponent<Foo>();
+    }
+}
+";
+			await VerifyCSharpFixAsync(test, fixedTest);
+		}
+
 		[Fact]
 		public async Task CreateMonoBehaviourInstance()
 		{
@@ -26,7 +64,7 @@ class Camera : MonoBehaviour
 }
 ";
 
-			var diagnostic = ExpectDiagnostic(CreateInstanceAnalyzer.MonoBehaviourId)
+			var diagnostic = ExpectDiagnostic(CreateInstanceAnalyzer.ComponentId)
 				.WithLocation(9, 19)
 				.WithArguments("Foo");
 
@@ -62,7 +100,7 @@ class Program
     }
 }
 ";
-			var diagnostic = ExpectDiagnostic(CreateInstanceAnalyzer.MonoBehaviourId).WithLocation(9, 19).WithArguments("Foo");
+			var diagnostic = ExpectDiagnostic(CreateInstanceAnalyzer.ComponentId).WithLocation(9, 19).WithArguments("Foo");
 			await VerifyCSharpDiagnosticAsync(test, diagnostic);
 		}
 

--- a/src/Microsoft.Unity.Analyzers/CreateInstance.cs
+++ b/src/Microsoft.Unity.Analyzers/CreateInstance.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Unity.Analyzers
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
 	public class CreateInstanceAnalyzer : DiagnosticAnalyzer
 	{
-		public const string MonoBehaviourId = "UNT0010";
+		public const string ComponentId = "UNT0010";
 
-		private static readonly DiagnosticDescriptor MonoBehaviourIdRule = new DiagnosticDescriptor(
-			MonoBehaviourId,
-			title: Strings.CreateMonoBehaviourInstanceDiagnosticTitle,
-			messageFormat: Strings.CreateMonoBehaviourInstanceDiagnosticMessageFormat,
+		private static readonly DiagnosticDescriptor ComponentIdRule = new DiagnosticDescriptor(
+			ComponentId,
+			title: Strings.CreateComponentInstanceDiagnosticTitle,
+			messageFormat: Strings.CreateComponentInstanceDiagnosticMessageFormat,
 			category: DiagnosticCategory.TypeSafety,
 			defaultSeverity: DiagnosticSeverity.Info,
 			isEnabledByDefault: true,
@@ -44,7 +44,7 @@ namespace Microsoft.Unity.Analyzers
 			isEnabledByDefault: true,
 			description: Strings.CreateScriptableObjectInstanceDiagnosticDescription);
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(MonoBehaviourIdRule, ScriptableObjectRule);
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ComponentIdRule, ScriptableObjectRule);
 
 		public override void Initialize(AnalysisContext context)
 		{
@@ -68,17 +68,17 @@ namespace Microsoft.Unity.Analyzers
 				return;
 			}
 
-			if (!typeInfo.Type.Extends(typeof(UnityEngine.MonoBehaviour)))
+			if (!typeInfo.Type.Extends(typeof(UnityEngine.Component)))
 				return;
 
-			context.ReportDiagnostic(Diagnostic.Create(MonoBehaviourIdRule, creation.GetLocation(), typeInfo.Type.Name));
+			context.ReportDiagnostic(Diagnostic.Create(ComponentIdRule, creation.GetLocation(), typeInfo.Type.Name));
 		}
 	}
 
 	[ExportCodeFixProvider(LanguageNames.CSharp)]
 	public class CreateInstanceCodeFix : CodeFixProvider
 	{
-		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(CreateInstanceAnalyzer.MonoBehaviourId, CreateInstanceAnalyzer.ScriptableObjectId);
+		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(CreateInstanceAnalyzer.ComponentId, CreateInstanceAnalyzer.ScriptableObjectId);
 
 		public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -104,9 +104,9 @@ namespace Microsoft.Unity.Analyzers
 							creation.ToFullString()),
 						context.Diagnostics);
 					break;
-				case CreateInstanceAnalyzer.MonoBehaviourId when !IsInsideComponent(creation, model):
+				case CreateInstanceAnalyzer.ComponentId when !IsInsideComponent(creation, model):
 					return;
-				case CreateInstanceAnalyzer.MonoBehaviourId:
+				case CreateInstanceAnalyzer.ComponentId:
 					context.RegisterCodeFix(
 						CodeAction.Create(
 							Strings.CreateMonoBehaviourInstanceCodeFixTitle,

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -88,6 +88,24 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Component &apos;{0}&apos; should not be instantiated directly..
+        /// </summary>
+        internal static string CreateComponentInstanceDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("CreateComponentInstanceDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Component instance creation.
+        /// </summary>
+        internal static string CreateComponentInstanceDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("CreateComponentInstanceDiagnosticTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use gameObject.AddComponent().
         /// </summary>
         internal static string CreateMonoBehaviourInstanceCodeFixTitle {
@@ -102,24 +120,6 @@ namespace Microsoft.Unity.Analyzers.Resources {
         internal static string CreateMonoBehaviourInstanceDiagnosticDescription {
             get {
                 return ResourceManager.GetString("CreateMonoBehaviourInstanceDiagnosticDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to MonoBehaviour &apos;{0}&apos; should not be instantiated directly..
-        /// </summary>
-        internal static string CreateMonoBehaviourInstanceDiagnosticMessageFormat {
-            get {
-                return ResourceManager.GetString("CreateMonoBehaviourInstanceDiagnosticMessageFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to MonoBehaviour instance creation.
-        /// </summary>
-        internal static string CreateMonoBehaviourInstanceDiagnosticTitle {
-            get {
-                return ResourceManager.GetString("CreateMonoBehaviourInstanceDiagnosticTitle", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -249,12 +249,12 @@
   <data name="CreateMonoBehaviourInstanceDiagnosticDescription" xml:space="preserve">
     <value>Use AddComponent() to create MonoBehaviours. A MonoBehaviour component needs to be attached to a GameObject.</value>
   </data>
-  <data name="CreateMonoBehaviourInstanceDiagnosticMessageFormat" xml:space="preserve">
-    <value>MonoBehaviour '{0}' should not be instantiated directly.</value>
+  <data name="CreateComponentInstanceDiagnosticMessageFormat" xml:space="preserve">
+    <value>Component '{0}' should not be instantiated directly.</value>
     <comment>{0} is a type name</comment>
   </data>
-  <data name="CreateMonoBehaviourInstanceDiagnosticTitle" xml:space="preserve">
-    <value>MonoBehaviour instance creation</value>
+  <data name="CreateComponentInstanceDiagnosticTitle" xml:space="preserve">
+    <value>Component instance creation</value>
   </data>
   <data name="CreateScriptableObjectInstanceCodeFixTitle" xml:space="preserve">
     <value>Use ScriptableObject.CreateInstance()</value>


### PR DESCRIPTION
Fixes #108 

#### Checklist
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Extend the existing rule to handle all components and not only MonoBehaviours. Interestingly, the code was already very oriented around the component concept.
