### PR TITLE
Fix NREs with ISymbol.ContainingNamespace

### DIFF
--- a/src/Microsoft.Unity.Analyzers/Reflection.cs
+++ b/src/Microsoft.Unity.Analyzers/Reflection.cs
@@ -90,7 +90,8 @@ namespace Microsoft.Unity.Analyzers
 			{
 				var typeInfo = context.SemanticModel.GetTypeInfo(node);
 				var typeSymbol = typeInfo.Type;
-				if (typeSymbol == null)
+
+				if (typeSymbol?.ContainingNamespace == null)
 					continue;
 
 				if (typeSymbol.ContainingNamespace.ToDisplayString() != srns)

--- a/src/Microsoft.Unity.Analyzers/TypeSymbolExtensions.cs
+++ b/src/Microsoft.Unity.Analyzers/TypeSymbolExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Unity.Analyzers
 			}
 
 			return named.Name == type.Name
-				&& named.ContainingNamespace.ToDisplayString() == type.Namespace;
+				&& named.ContainingNamespace?.ToDisplayString() == type.Namespace;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #124 

#### Checklist
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;

#### Short description of what this resolves:
We could hit NRE on `ToDisplayString()` given `ISymbol.ContainingNamespace` might be null. 