### PR TITLE
Target .net core 3.1 LTS for the new-analyzer project

### DIFF
--- a/src/new-analyzer/new-analyzer.csproj
+++ b/src/new-analyzer/new-analyzer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>NewAnalyzer</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes a build warning on .NET Core 5.
