### PR TITLE
Resolved: Using [UnityEditor.MenuItem] causes "Private member is unused"

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/ContextMenuSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ContextMenuSuppressorTests.cs
@@ -115,8 +115,6 @@ class Menu : MonoBehaviour
 			await VerifyCSharpDiagnosticAsync(test, suppressor);
 		}
 
-		/////
-		///
 		[Fact]
 		public async Task OutsideMonoBehaviourMenuItemSuppressed()
 		{

--- a/src/Microsoft.Unity.Analyzers.Tests/ContextMenuSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ContextMenuSuppressorTests.cs
@@ -115,5 +115,28 @@ class Menu : MonoBehaviour
 			await VerifyCSharpDiagnosticAsync(test, suppressor);
 		}
 
+		/////
+		///
+		[Fact]
+		public async Task OutsideMonoBehaviourMenuItemSuppressed()
+		{
+			const string test = @"
+using UnityEditor;
+
+static class TestCode
+{
+    [MenuItem(""Test/Hello World"")]
+    static void DoMenuItem()
+    {
+        EditorUtility.DisplayDialog(""Hello"", ""World"", ""OK"");
+    }
+}";
+
+			var suppressor = ExpectSuppressor(ContextMenuSuppressor.ContextMenuRule)
+				.WithLocation(7, 17);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+
 	}
 }

--- a/src/Microsoft.Unity.Analyzers.Tests/UnusedMethodSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnusedMethodSuppressorTests.cs
@@ -60,9 +60,8 @@ class A : MonoBehaviour
 
 			var suppressor = ExpectSuppressor(UnusedMethodSuppressor.Rule)
 				.WithLocation(15, 14);
-			
+
 			await VerifyCSharpDiagnosticAsync(test, suppressor);
 		}
 	}
 }
-

--- a/src/Microsoft.Unity.Analyzers.Tests/UnusedMethodSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnusedMethodSuppressorTests.cs
@@ -60,8 +60,11 @@ class A : MonoBehaviour
 
 			var suppressor = ExpectSuppressor(UnusedMethodSuppressor.Rule)
 				.WithLocation(15, 14);
-
+			
 			await VerifyCSharpDiagnosticAsync(test, suppressor);
 		}
+
+		
 	}
 }
+

--- a/src/Microsoft.Unity.Analyzers.Tests/UnusedMethodSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnusedMethodSuppressorTests.cs
@@ -63,8 +63,6 @@ class A : MonoBehaviour
 			
 			await VerifyCSharpDiagnosticAsync(test, suppressor);
 		}
-
-		
 	}
 }
 

--- a/src/Microsoft.Unity.Analyzers/ContextMenuSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/ContextMenuSuppressor.cs
@@ -96,7 +96,6 @@ namespace Microsoft.Unity.Analyzers
 				case IFieldSymbol fieldSymbol:
 					if (fieldSymbol.GetAttributes().Any(a => a.AttributeClass.Matches(typeof(UnityEngine.ContextMenuItemAttribute))))
 						return true;
-
 					break;
 			}
 

--- a/src/Microsoft.Unity.Analyzers/ContextMenuSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/ContextMenuSuppressor.cs
@@ -84,8 +84,6 @@ namespace Microsoft.Unity.Analyzers
 				return false;
 
 			var containingType = symbol.ContainingType;
-			if (!containingType.Extends(typeof(UnityEngine.MonoBehaviour)))
-				return false;
 
 			switch (symbol)
 			{
@@ -98,6 +96,7 @@ namespace Microsoft.Unity.Analyzers
 				case IFieldSymbol fieldSymbol:
 					if (fieldSymbol.GetAttributes().Any(a => a.AttributeClass.Matches(typeof(UnityEngine.ContextMenuItemAttribute))))
 						return true;
+
 					break;
 			}
 


### PR DESCRIPTION
Fixes #127
-Using [UnityEditor.MenuItem] causes "Private member is unused"
