### PR TITLE
Bump packages

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/Directory.Build.props
+++ b/src/Microsoft.Unity.Analyzers.Tests/Directory.Build.props
@@ -8,7 +8,8 @@
   <Import Project="$(VstuDirectory)build\UnityVS.Signing.props" Condition="Exists('$(VstuDirectory)build\UnityVS.Signing.props')" />
 
   <PropertyGroup Condition="Exists('$(VstuDirectory)build\UnityVS.props')">  
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <!-- Tests are using a distinct Roslyn version, so use a dedicated folder to host assembly output -->
+    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <Configurations>Debug;Release;DebugRelease</Configurations>
   </PropertyGroup>
 

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/CodeFixVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/CodeFixVerifier.cs
@@ -91,8 +91,8 @@ namespace Microsoft.Unity.Analyzers.Tests
 
 		private static IEnumerable<Diagnostic> GetNewDiagnostics(IEnumerable<Diagnostic> diagnostics, IEnumerable<Diagnostic> newDiagnostics)
 		{
-			var oldArray = diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
-			var newArray = newDiagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
+			var oldArray = FilterDiagnostics(diagnostics).OrderBy(d => d.Location.SourceSpan.Start).ToArray();
+			var newArray = FilterDiagnostics(newDiagnostics).OrderBy(d => d.Location.SourceSpan.Start).ToArray();
 
 			var oldIndex = 0;
 			var newIndex = 0;

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Unity.Analyzers.Tests
 			{
 				var newFileName = DefaultFilePathPrefix + count + "." + CSharpDefaultFileExt;
 				var documentId = DocumentId.CreateNewId(projectId, newFileName);
-				solution = solution.AddDocument(documentId, newFileName, SourceText.From(source), filePath: @"z:\" + newFileName); 
+				solution = solution.AddDocument(documentId, newFileName, SourceText.From(source), filePath: @"/" + newFileName); 
 				count++;
 			}
 

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
@@ -279,7 +279,7 @@ namespace Microsoft.Unity.Analyzers.Tests
 			return diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
 		}
 
-		private Document[] GetDocuments(string[] sources)
+		private static Document[] GetDocuments(string[] sources)
 		{
 			var project = CreateProject(sources);
 			var documents = project.Documents.ToArray();
@@ -292,7 +292,7 @@ namespace Microsoft.Unity.Analyzers.Tests
 			return documents;
 		}
 
-		protected Document CreateDocument(string source)
+		protected static Document CreateDocument(string source)
 		{
 			return CreateProject(new[] { source }).Documents.First();
 		}
@@ -333,7 +333,7 @@ namespace Microsoft.Unity.Analyzers.Tests
 			yield return Path.Combine(monolib, "system.dll");
 		}
 
-		private Project CreateProject(string[] sources)
+		private static Project CreateProject(string[] sources)
 		{
 			var projectId = ProjectId.CreateNewId(TestProjectName);
 

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
@@ -24,16 +24,6 @@ namespace Microsoft.Unity.Analyzers.Tests
 		private const string CSharpDefaultFileExt = "cs";
 		private const string TestProjectName = "TestProject";
 
-		protected virtual string EditorConfig => @"
-is_global = true
-[*]
-# Assuming assembly reference 'mscorlib, Version=2.0.0.0' used by 'UnityEngine' matches identity 'mscorlib, Version=4.0.0.0' of 'mscorlib', you may need to supply runtime policy
-dotnet_diagnostic.CS1701.severity = none
-
-# cf. IDE0051
-dotnet_diagnostic.CS0414.severity = none
-";
-
 		protected abstract DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer();
 
 		protected virtual IEnumerable<DiagnosticAnalyzer> GetRelatedAnalyzers(DiagnosticAnalyzer analyzer)
@@ -271,9 +261,17 @@ dotnet_diagnostic.CS0414.severity = none
 				}
 			}
 
-			var results = SortDiagnostics(diagnostics);
+			var results = SortDiagnostics(FilterDiagnostics(diagnostics));
 			diagnostics.Clear();
 			return results;
+		}
+
+		protected static Diagnostic[] FilterDiagnostics(IEnumerable<Diagnostic> diagnostics)
+		{
+			return diagnostics
+				.Where(d => d.Id != "CS1701") // Assuming assembly reference 'mscorlib, Version=2.0.0.0' used by 'UnityEngine' matches identity 'mscorlib, Version=4.0.0.0' of 'mscorlib', you may need to supply runtime policy
+				.Where(d => d.Id != "CS0414") // IDE0051
+				.ToArray();
 		}
 
 		private static Diagnostic[] SortDiagnostics(IEnumerable<Diagnostic> diagnostics)
@@ -337,28 +335,20 @@ dotnet_diagnostic.CS0414.severity = none
 
 		private Project CreateProject(string[] sources)
 		{
-			var fileNamePrefix = DefaultFilePathPrefix;
-			var fileExt = CSharpDefaultFileExt;
-
 			var projectId = ProjectId.CreateNewId(TestProjectName);
 
 			var solution = new AdhocWorkspace()
 				.CurrentSolution
 				.AddProject(projectId, TestProjectName, TestProjectName, LanguageNames.CSharp);
 
-			const string editorconfig = ".editorconfig";
-			var ecId = DocumentId.CreateNewId(projectId, editorconfig);
-			var analyzerConfigSource = SourceText.From(EditorConfig);
-
-			solution = solution.AddAnalyzerConfigDocument(ecId, editorconfig, analyzerConfigSource, filePath: @"/" + editorconfig);
 			solution = UnityAssemblies().Aggregate(solution, (current, dll) => current.AddMetadataReference(projectId, MetadataReference.CreateFromFile(dll)));
 
 			var count = 0;
 			foreach (var source in sources)
 			{
-				var newFileName = fileNamePrefix + count + "." + fileExt;
+				var newFileName = DefaultFilePathPrefix + count + "." + CSharpDefaultFileExt;
 				var documentId = DocumentId.CreateNewId(projectId, newFileName);
-				solution = solution.AddDocument(documentId, newFileName, SourceText.From(source), filePath: @"/" + newFileName); // keep path in sync with editorconfig
+				solution = solution.AddDocument(documentId, newFileName, SourceText.From(source), filePath: @"z:\" + newFileName); 
 				count++;
 			}
 

--- a/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
+++ b/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
@@ -5,17 +5,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-3.20177.13" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.3.0" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.7.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.3.1" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.8.3" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />    
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.7.56" PrivateAssets="all" />	
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.8.55" PrivateAssets="all" />	
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
@@ -71,7 +71,7 @@ public class TestScript : MonoBehaviour
 				ExpectSuppressor(NullableReferenceTypesSuppressor.Rule).WithLocation(18, 27), //staticField
 
 				DiagnosticResult.CompilerWarning("CS8618")
-					.WithMessage("Non-nullable field 'hiddenField' is uninitialized. Consider declaring the field as nullable.")
+					.WithMessage("Non-nullable field 'hiddenField' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.")
 					.WithLocation(20, 38), //should throw on public fields that are not shown in the inspector
 				
 				ExpectSuppressor(NullableReferenceTypesSuppressor.Rule).WithLocation(21, 38)

--- a/src/Microsoft.Unity.Analyzers/Microsoft.Unity.Analyzers.csproj
+++ b/src/Microsoft.Unity.Analyzers/Microsoft.Unity.Analyzers.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.7.56" PrivateAssets="all" />	
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.8.55" PrivateAssets="all" />	
   </ItemGroup>
   
   <ItemGroup>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="roslyn-analyzers" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
-    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
+    <clear />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>


### PR DESCRIPTION
#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] I have added tests that prove my fix is effective or that my feature works ;

#### Short description of what this resolves:
Bump packages to the latest versions.

Note that we only bump Roslyn on the test side, Our analyzers are still targeting 3.4.0.

I reverted the EditorConfig filtering, as I was not able to make it work with a newer Roslyn (we are now filtering in code)...

In the near future, we'll have to migrate from FxCop analyzers to .NET analyzers. (but all diagnostics are not there yet).
See https://docs.microsoft.com/en-us/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers?view=vs-2019


