### PR TITLE
Force tested analyzers to be enabled (even when IsEnabledByDefault is false)

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
@@ -230,8 +230,15 @@ namespace Microsoft.Unity.Analyzers.Tests
 				var options = new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty, optionsProvider);
 				var analyzerOptions = new CompilationWithAnalyzersOptions(options, null, true, true, true);
 
+				var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, reportSuppressedDiagnostics: true);
+				var specificDiagnosticOptions = compilationOptions.SpecificDiagnosticOptions;
+
+				// Force all tested diagnostics to be enabled
+				foreach (var descriptor in analyzer.SupportedDiagnostics)
+					specificDiagnosticOptions = specificDiagnosticOptions.SetItem(descriptor.Id, ReportDiagnostic.Info);
+
 				var compilationWithAnalyzers = compilation
-					.WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, reportSuppressedDiagnostics: true))
+					.WithOptions(compilationOptions.WithSpecificDiagnosticOptions(specificDiagnosticOptions))
 					.WithAnalyzers(analyzers, analyzerOptions);
 
 				var allDiagnostics = await compilationWithAnalyzers.GetAllDiagnosticsAsync();

--- a/src/Microsoft.Unity.Analyzers.Tests/UpdateDeltaTimeTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UpdateDeltaTimeTests.cs
@@ -26,15 +26,13 @@ class Camera : MonoBehaviour
 ";
 			// see https://github.com/microsoft/Microsoft.Unity.Analyzers/issues/26
 			// this rule is now disabled by default
-			await VerifyCSharpDiagnosticAsync(test);
-
 			// but can be re-enabled using ruleset or editorconfig:
 			// dotnet_diagnostic.UNT0005.severity = suggestion
 
-			/*var diagnostic = ExpectDiagnostic(UpdateDeltaTimeAnalyzer.FixedUpdateId)
+			var diagnostic = ExpectDiagnostic(UpdateDeltaTimeAnalyzer.FixedUpdateId)
 				.WithLocation(8, 25);
 
-			VerifyCSharpDiagnosticAsync(test, diagnostic);
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
 
 			const string fixedTest = @"
 using UnityEngine;
@@ -47,7 +45,7 @@ class Camera : MonoBehaviour
      }
 }
 ";
-			await VerifyCSharpFixAsync(test, fixedTest);*/
+			await VerifyCSharpFixAsync(test, fixedTest);
 		}
 
 		[Fact]


### PR DESCRIPTION
#### Checklist
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Previously, when adding analyzer-rules using a descriptor with `IsEnabledByDefault = false`, analyzer testing was not possible.
