### PR TITLE
Refactor SetPositionAndRotationAnalyzer

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/SetPositionAndRotationTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/SetPositionAndRotationTests.cs
@@ -76,6 +76,7 @@ class Camera : MonoBehaviour
     {
         transform.position = new Vector3(0.0f, 1.0f, 0.0f);
     }
+
     void Update()
     {
         transform.rotation = transform.rotation;

--- a/src/Microsoft.Unity.Analyzers/SetPositionAndRotation.cs
+++ b/src/Microsoft.Unity.Analyzers/SetPositionAndRotation.cs
@@ -34,9 +34,8 @@ namespace Microsoft.Unity.Analyzers
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-		internal const string position = "position";
-		
-		internal const string rotation = "rotation";
+		internal const string Position = "position";
+		internal const string Rotation = "rotation";
 
 		public override void Initialize(AnalysisContext context)
 		{
@@ -50,51 +49,54 @@ namespace Microsoft.Unity.Analyzers
 			if (!(context.Node is AssignmentExpressionSyntax assignmentExpression))
 				return;
 
-			if (!IsSetPositionOrRotation(assignmentExpression, context.SemanticModel))
-				return;
-
-
-			if (context.Node.FirstAncestorOrSelf<BlockSyntax>() == null)
-				return;
-
-			if (context.Node.FirstAncestorOrSelf<ExpressionStatementSyntax>() == null)
-				return;
-			
-			var block = context.Node.FirstAncestorOrSelf<BlockSyntax>();
-
-			var siblingsAndSelf = block.ChildNodes().ToImmutableArray();
-			
-			var expression = context.Node.FirstAncestorOrSelf<ExpressionStatementSyntax>();
-
-			if (siblingsAndSelf.LastIndexOf(expression) == -1)
-				return;
-
-			var currentIndex = siblingsAndSelf.LastIndexOf(expression);
-
-			var nextIndex = currentIndex + 1;
-
-			if (nextIndex == siblingsAndSelf.Length)
-				return;
-
-			var statement = siblingsAndSelf[nextIndex];
-
-			if (!(statement is ExpressionStatementSyntax expressionStatement))
-				return;
-
-			if (!(expressionStatement.Expression is AssignmentExpressionSyntax nextAssignmentExpression))
-				return;
-
-			if (!IsSetPositionOrRotation(nextAssignmentExpression, context.SemanticModel))
+			if (!GetNextAssignmentExpression(context.SemanticModel, assignmentExpression, out var nextAssignmentExpression)) 
 				return;
 
 			var property = GetProperty(assignmentExpression);
-
 			var nextProperty = GetProperty(nextAssignmentExpression);
-
 			if (property == nextProperty)
 				return;
 
 			context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation()));
+		}
+
+		internal static bool GetNextAssignmentExpression(SemanticModel model, AssignmentExpressionSyntax assignmentExpression, out AssignmentExpressionSyntax assignmentExpressionSyntax)
+		{
+			assignmentExpressionSyntax = null;
+
+			if (!IsSetPositionOrRotation(model, assignmentExpression))
+				return false;
+
+			if (assignmentExpression.FirstAncestorOrSelf<BlockSyntax>() == null)
+				return false;
+
+			if (assignmentExpression.FirstAncestorOrSelf<ExpressionStatementSyntax>() == null)
+				return false;
+
+			var block = assignmentExpression.FirstAncestorOrSelf<BlockSyntax>();
+			var siblingsAndSelf = block.ChildNodes().ToImmutableArray();
+			var expression = assignmentExpression.FirstAncestorOrSelf<ExpressionStatementSyntax>();
+
+			var lastIndexOf = siblingsAndSelf.LastIndexOf(expression);
+			if (lastIndexOf == -1)
+				return false;
+
+			var nextIndex = lastIndexOf + 1;
+			if (nextIndex == siblingsAndSelf.Length)
+				return false;
+
+			var statement = siblingsAndSelf[nextIndex];
+			if (!(statement is ExpressionStatementSyntax expressionStatement))
+				return false;
+
+			if (!(expressionStatement.Expression is AssignmentExpressionSyntax nextAssignmentExpression))
+				return false;
+
+			if (!IsSetPositionOrRotation(model, nextAssignmentExpression))
+				return false;
+
+			assignmentExpressionSyntax = nextAssignmentExpression;
+			return true;
 		}
 
 		internal static string GetProperty(AssignmentExpressionSyntax assignmentExpression)
@@ -105,27 +107,20 @@ namespace Microsoft.Unity.Analyzers
 			return left.Name.ToString();
 		}
 
-		private static bool IsSetPositionOrRotation(AssignmentExpressionSyntax assignmentExpression, SemanticModel model)
+		private static bool IsSetPositionOrRotation(SemanticModel model, AssignmentExpressionSyntax assignmentExpression)
 		{
+			var property = GetProperty(assignmentExpression);
+			if (property != Position && property != Rotation)
+				return false;
 
 			if (!(assignmentExpression.Left is MemberAccessExpressionSyntax left))
 				return false;
 
-			var property = GetProperty(assignmentExpression);
-
-			if (property != position && property != rotation)
-				return false;
-
 			var leftSymbol = model.GetSymbolInfo(left);
-
-			if (leftSymbol.Symbol == null)
-				return false;
-
 			if (!(leftSymbol.Symbol is IPropertySymbol))
 				return false;
 
 			var leftExpressionTypeInfo = model.GetTypeInfo(left.Expression);
-
 			if (leftExpressionTypeInfo.Type == null)
 				return false;
 
@@ -150,46 +145,21 @@ namespace Microsoft.Unity.Analyzers
 			context.RegisterCodeFix(
 				CodeAction.Create(
 					Strings.SetPositionAndRotationCodeFixTitle,
-					ct => ReplaceWithInvocationAsync(context.Document, expression, "transform", "SetPositionAndRotation", ct),
+					ct => ReplaceWithInvocationAsync(context.Document, expression, ct),
 					expression.ToFullString()),
 				context.Diagnostics);
 		}
-		private static async Task<Document> ReplaceWithInvocationAsync(Document document, AssignmentExpressionSyntax assignmentExpression, string identifierName, string methodName, CancellationToken cancellationToken)
+
+		private static async Task<Document> ReplaceWithInvocationAsync(Document document, AssignmentExpressionSyntax assignmentExpression, CancellationToken cancellationToken)
 		{
-			if (assignmentExpression.FirstAncestorOrSelf<BlockSyntax>() == null)
+			var model = await document.GetSemanticModelAsync(cancellationToken);
+			if (!SetPositionAndRotationAnalyzer.GetNextAssignmentExpression(model, assignmentExpression, out var nextAssignmentExpression)) 
 				return document;
-
-			var block = assignmentExpression.FirstAncestorOrSelf<BlockSyntax>();
-
-			if (assignmentExpression.FirstAncestorOrSelf<ExpressionStatementSyntax>() == null)
-				return document;
-
-			var expression = assignmentExpression.FirstAncestorOrSelf<ExpressionStatementSyntax>();
-
-			var siblingsAndSelf = block.ChildNodes().ToImmutableArray();
-
-			if (siblingsAndSelf.LastIndexOf(expression) == -1)
-				return document;
-
-			var currentIndex = siblingsAndSelf.LastIndexOf(expression);
-
-			var nextIndex = currentIndex + 1;
-
-			if (nextIndex == siblingsAndSelf.Length)
-				return document;
-
-			var statement = siblingsAndSelf[nextIndex];
-
-			if (!(statement is ExpressionStatementSyntax expressionStatement))
-				return document;
-
-			if (!(expressionStatement.Expression is AssignmentExpressionSyntax nextAssignmentExpression))
-				return null;
 
 			var property = SetPositionAndRotationAnalyzer.GetProperty(assignmentExpression);
-
 			var arguments = new[] {Argument(assignmentExpression.Right), Argument(nextAssignmentExpression.Right)};
-			if (property != SetPositionAndRotationAnalyzer.position)
+
+			if (property != SetPositionAndRotationAnalyzer.Position)
 				Array.Reverse(arguments);
 
 			var argList = ArgumentList()
@@ -198,16 +168,15 @@ namespace Microsoft.Unity.Analyzers
 			var invocation = InvocationExpression(
 					MemberAccessExpression(
 						SyntaxKind.SimpleMemberAccessExpression,
-						IdentifierName(identifierName),
-						IdentifierName(methodName)))
+						IdentifierName("transform"),
+						IdentifierName("SetPositionAndRotation")))
 				.WithArgumentList(argList);
 
 			var documentEditor = await DocumentEditor.CreateAsync(document, cancellationToken);
-			documentEditor.RemoveNode(statement);
+			documentEditor.RemoveNode(nextAssignmentExpression.Parent);
 			documentEditor.ReplaceNode(assignmentExpression, invocation);
 
 			return documentEditor.GetChangedDocument();
-
 		}
 	}
 }


### PR DESCRIPTION
@shreyalpandit 

I refactored your analyzer/codefix by extracting the following duplicate code into a method:

```
			if (assignmentExpression.FirstAncestorOrSelf<BlockSyntax>() == null)
				return document;

			if (assignmentExpression.FirstAncestorOrSelf<ExpressionStatementSyntax>() == null)
				return document;


			var siblingsAndSelf = block.ChildNodes().ToImmutableArray();
			var block = assignmentExpression.FirstAncestorOrSelf<BlockSyntax>();
			var expression = assignmentExpression.FirstAncestorOrSelf<ExpressionStatementSyntax>();

			var lastIndexOf = siblingsAndSelf.LastIndexOf(expression);
			if (lastIndexOf == -1)
				return document;

			var nextIndex = lastIndexOf + 1;
			if (nextIndex == siblingsAndSelf.Length)
				return document;

			var statement = siblingsAndSelf[nextIndex];

			if (!(statement is ExpressionStatementSyntax expressionStatement))
				return document;

			if (!(expressionStatement.Expression is AssignmentExpressionSyntax nextAssignmentExpression))
				return null;
```

What do you think?


