### PR TITLE
Avoid calling GetSymbolInfo until we need to

### DIFF
--- a/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
+++ b/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
@@ -37,6 +37,13 @@ namespace Microsoft.Unity.Analyzers
 		private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
 		{
 			var invocation = (InvocationExpressionSyntax)context.Node;
+			var name = invocation.GetMethodNameSyntax();
+			if (name == null)
+				return;
+
+			if (!KnownMethods.IsGetComponentName(name))
+				return;
+
 			var symbol = context.SemanticModel.GetSymbolInfo(invocation);
 
 			if (symbol.Symbol is not IMethodSymbol method)

--- a/src/Microsoft.Unity.Analyzers/InvocationExpressionSyntaxExtensions.cs
+++ b/src/Microsoft.Unity.Analyzers/InvocationExpressionSyntaxExtensions.cs
@@ -14,8 +14,7 @@ namespace Microsoft.Unity.Analyzers
 			return expr.Expression switch
 			{
 				MemberAccessExpressionSyntax mae => mae.Name,
-				IdentifierNameSyntax ins => ins,
-				GenericNameSyntax gns => gns,
+				SimpleNameSyntax sns => sns,
 				_ => null,
 			};
 		}

--- a/src/Microsoft.Unity.Analyzers/InvocationExpressionSyntaxExtensions.cs
+++ b/src/Microsoft.Unity.Analyzers/InvocationExpressionSyntaxExtensions.cs
@@ -11,20 +11,13 @@ namespace Microsoft.Unity.Analyzers
 	{
 		public static SimpleNameSyntax? GetMethodNameSyntax(this InvocationExpressionSyntax expr)
 		{
-			SimpleNameSyntax? nameSyntax = null;
-
-			switch (expr.Expression)
+			return expr.Expression switch
 			{
-				case MemberAccessExpressionSyntax mae:
-					nameSyntax = mae.Name;
-					break;
-				case IdentifierNameSyntax ies:
-					nameSyntax = ies;
-					break;
-			}
-
-			return nameSyntax;
+				MemberAccessExpressionSyntax mae => mae.Name,
+				IdentifierNameSyntax ins => ins,
+				GenericNameSyntax gns => gns,
+				_ => null,
+			};
 		}
-
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/InvocationExpressionSyntaxExtensions.cs
+++ b/src/Microsoft.Unity.Analyzers/InvocationExpressionSyntaxExtensions.cs
@@ -1,0 +1,30 @@
+﻿/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.Unity.Analyzers
+{
+	internal static class InvocationExpressionSyntaxExtensions
+	{
+		public static SimpleNameSyntax? GetMethodNameSyntax(this InvocationExpressionSyntax expr)
+		{
+			SimpleNameSyntax? nameSyntax = null;
+
+			switch (expr.Expression)
+			{
+				case MemberAccessExpressionSyntax mae:
+					nameSyntax = mae.Name;
+					break;
+				case IdentifierNameSyntax ies:
+					nameSyntax = ies;
+					break;
+			}
+
+			return nameSyntax;
+		}
+
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/KnownMethods.cs
+++ b/src/Microsoft.Unity.Analyzers/KnownMethods.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.Unity.Analyzers
 {
@@ -20,6 +21,8 @@ namespace Microsoft.Unity.Analyzers
 			nameof(UnityEngine.Component.GetComponentsInChildren),
 			nameof(UnityEngine.Component.GetComponentsInParent),
 		});
+
+		public static bool IsGetComponentName(SimpleNameSyntax name) => GetComponentNames.Contains(name.Identifier.Text);
 
 		public static bool IsGetComponent(IMethodSymbol method)
 		{

--- a/src/Microsoft.Unity.Analyzers/NonGenericGetComponent.cs
+++ b/src/Microsoft.Unity.Analyzers/NonGenericGetComponent.cs
@@ -45,6 +45,13 @@ namespace Microsoft.Unity.Analyzers
 		private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
 		{
 			var invocation = (InvocationExpressionSyntax)context.Node;
+			var name = invocation.GetMethodNameSyntax();
+			if (name == null)
+				return;
+
+			if (!KnownMethods.IsGetComponentName(name))
+				return;
+
 			var symbol = context.SemanticModel.GetSymbolInfo(invocation);
 			if (symbol.Symbol == null)
 				return;

--- a/src/Microsoft.Unity.Analyzers/UnusedCoroutineReturnValue.cs
+++ b/src/Microsoft.Unity.Analyzers/UnusedCoroutineReturnValue.cs
@@ -37,14 +37,14 @@ namespace Microsoft.Unity.Analyzers
 		private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
 		{
 			var invocation = (InvocationExpressionSyntax)context.Node;
+			if (!invocation.Parent.IsKind(SyntaxKind.ExpressionStatement))
+				return;
+
 			var symbol = context.SemanticModel.GetSymbolInfo(invocation);
 			if (symbol.Symbol == null)
 				return;
 
 			if (!IsValidCoroutine(symbol.Symbol, out var methodName))
-				return;
-
-			if (!invocation.Parent.IsKind(SyntaxKind.ExpressionStatement))
 				return;
 
 			context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), methodName));


### PR DESCRIPTION
`GetSymbolInfo` is pretty costly. We found cases of projects where we'd spend an enormous amount of time in there, depending on the code patterns.

We need to do as much work as possible to filter the patterns we want to provide a diagnostic for before calling GetSymbolInfo.

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
