### PR TITLE
Add ScriptedImporter to Unity stubs

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/MessageSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/MessageSuppressorTests.cs
@@ -73,5 +73,48 @@ public class TestScript : MonoBehaviour
 
 			await VerifyCSharpDiagnosticAsync(test, suppressor);
 		}
+
+		[Fact]
+		public async Task UnusedMethodScriptedImporterSuppressed()
+		{
+			const string test = @"
+using System;
+using UnityEditor.AssetImporters;
+
+internal class Test : ScriptedImporter
+{
+    private void Reset()
+    {
+    }
+
+    private static string[] GatherDependenciesFromSourceFile(string assetPath)
+    {
+        return null;
+    }
+
+    private void OnValidate()
+    {
+    }
+
+    public override void OnImportAsset(AssetImportContext ctx)
+    {
+    }
+
+    public override bool SupportsRemappedAssetType(Type type)
+    {
+        return true;
+    }
+}
+";
+
+			var suppressors = new[] {
+				ExpectSuppressor(MessageSuppressor.MethodRule).WithLocation(7, 18),
+				ExpectSuppressor(MessageSuppressor.MethodRule).WithLocation(11, 29),
+				ExpectSuppressor(MessageSuppressor.ParameterRule).WithLocation(11, 69),
+				ExpectSuppressor(MessageSuppressor.MethodRule).WithLocation(16, 18),
+			};
+
+			await VerifyCSharpDiagnosticAsync(test, suppressors);
+		}
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/ScriptInfo.cs
+++ b/src/Microsoft.Unity.Analyzers/ScriptInfo.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Unity.Analyzers
 			typeof(UnityEditor.Editor),
 			typeof(UnityEngine.ScriptableObject),
 			typeof(UnityEngine.MonoBehaviour),
-			typeof(UnityEditor.AssetPostprocessor)
+			typeof(UnityEditor.AssetPostprocessor),
+			typeof(UnityEditor.AssetImporters.ScriptedImporter)
 		};
 
 		private readonly ITypeSymbol _symbol;

--- a/src/Microsoft.Unity.Analyzers/UnityStubs.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityStubs.cs
@@ -724,6 +724,13 @@ namespace UnityEditor.AssetImporters
 	class MaterialDescription
 	{
 	}
+
+	class ScriptedImporter
+	{
+		static string[] GatherDependenciesFromSourceFile(string assetPath) { return null; }
+		void OnValidate() { }
+		void Reset() { }
+	}
 }
 
 namespace UnityEditor


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #163<!--Enter Issue number you have referenced(please refer only one issue at once)-->

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Add Unity messages for the type `ScriptedImporter`, to properly suppress methods/parameters warnings.

#### Changes proposed in this pull request:
Add missing type/methods to UnityStubs, and add a new Reference to `ScriptedImporter` in `ScriptInfo` 
