### PR TITLE
Do not warn for overridden messages

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/ProtectedUnityMessageTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ProtectedUnityMessageTests.cs
@@ -215,5 +215,22 @@ public sealed class Camera : MonoBehaviour
 
 			await VerifyCSharpDiagnosticAsync(test);
 		}
+
+		[Fact]
+		public async Task ShouldNotWarnForOverride()
+		{
+			const string test = @"
+using UnityEngine;
+
+class StateMachine : StateMachineBehaviour
+{
+    public override void OnStateEnter(Animator animator, AnimatorStateInfo animatorStateInfo, int layerIndex)
+    {
+    }
+}
+";
+
+			await VerifyCSharpDiagnosticAsync(test);
+		}
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/ProtectedUnityMessage.cs
+++ b/src/Microsoft.Unity.Analyzers/ProtectedUnityMessage.cs
@@ -59,6 +59,10 @@ namespace Microsoft.Unity.Analyzers
 			if (!scriptInfo.IsMessage(symbol))
 				return;
 
+			// In this case the scope is enforced
+			if (symbol.IsOverride)
+				return;
+
 			context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation()));
 		}
 	}


### PR DESCRIPTION
Fixes #187 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
We should not warn for overridden messages, given they will use the scope of the member definition. This rule is only interesting for regular messages. So check the `IsOverride`  on the method symbol.
