### PR TITLE
Bump Unity to 2020.3.24f1

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -11,8 +11,8 @@ on:
     - release/*
 
 env:
-  UNITY_HASH: 41c4e627c95f
-  UNITY_FULL_VERSION: 2020.3.20f1
+  UNITY_HASH: 79c78de19888
+  UNITY_FULL_VERSION: 2020.3.24f1
   
 jobs:
   macos:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -11,8 +11,8 @@ on:
     - release/*
 
 env:
-  UNITY_HASH: 41c4e627c95f
-  UNITY_FULL_VERSION: 2020.3.20f1
+  UNITY_HASH: 79c78de19888
+  UNITY_FULL_VERSION: 2020.3.24f1
 
 jobs:
   windows:


### PR DESCRIPTION
#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;

#### Short description of what this resolves:
Bump Unity to 2020.3.24f1 LTS