### PR TITLE
Fix USP0016 for non unity objects

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
@@ -48,7 +48,6 @@ namespace Assets.Scripts
 			DiagnosticResult.CompilerWarning("CS8618")
 				.WithMessage("Non-nullable property 'property1' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.")
 				.WithLocation(11, 28), 
-
 		};
 
 		await VerifyCSharpDiagnosticAsync(context, test, diagnostics);

--- a/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
@@ -25,13 +25,19 @@ namespace Assets.Scripts
     {
         private class NonUnityObject { }
 
-        private GameObject field;
+        private GameObject field1;
         private NonUnityObject field2;
+        
+        private GameObject property1 { get; set; }
+        private NonUnityObject property2 { get; set; }
 
         private void Start()
         {
-            field = new GameObject();
+            field1 = new GameObject();
             field2 = new NonUnityObject();
+
+            property1 = new GameObject();
+            property2 = new NonUnityObject();
         }
     }
 }
@@ -43,8 +49,10 @@ namespace Assets.Scripts
 
 		DiagnosticResult[] suppressors =
 		{
-			ExpectSuppressor(NullableReferenceTypesSuppressor.Rule).WithLocation(11, 28), //field
+			ExpectSuppressor(NullableReferenceTypesSuppressor.Rule).WithLocation(11, 28), //field1
 			ExpectSuppressor(NullableReferenceTypesSuppressor.Rule).WithLocation(12, 32), //field2
+			ExpectSuppressor(NullableReferenceTypesSuppressor.Rule).WithLocation(14, 28), //property1
+			ExpectSuppressor(NullableReferenceTypesSuppressor.Rule).WithLocation(15, 32), //property2
 		};
 
 		await VerifyCSharpDiagnosticAsync(context, test, suppressors);

--- a/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
@@ -11,6 +11,45 @@ namespace Microsoft.Unity.Analyzers.Tests;
 
 public class NullableReferenceTypesSuppressorTest : BaseSuppressorVerifierTest<NullableReferenceTypesSuppressor>
 {
+
+	[Fact]
+	public async Task NonUnityNullableReferenceTypesSuppressed()
+	{
+		const string test = @"
+#nullable enable
+using UnityEngine;
+
+namespace Assets.Scripts
+{
+    public class Test : MonoBehaviour
+    {
+        private class NonUnityObject { }
+
+        private GameObject field;
+        private NonUnityObject field2;
+
+        private void Start()
+        {
+            field = new GameObject();
+            field2 = new NonUnityObject();
+        }
+    }
+}
+"; 
+
+		var context = AnalyzerVerificationContext.Default
+			.WithLanguageVersion(LanguageVersion.CSharp8)
+			.WithAnalyzerFilter("CS0169");
+
+		DiagnosticResult[] suppressors =
+		{
+			ExpectSuppressor(NullableReferenceTypesSuppressor.Rule).WithLocation(11, 28), //field
+			ExpectSuppressor(NullableReferenceTypesSuppressor.Rule).WithLocation(12, 32), //field2
+		};
+
+		await VerifyCSharpDiagnosticAsync(context, test, suppressors);
+	}
+
 	[Fact]
 	public async Task NullableReferenceTypesSuppressed()
 	{
@@ -55,7 +94,7 @@ public class TestScript : MonoBehaviour
 	}
 }
 ";
-		DiagnosticResult[] suppressor =
+		DiagnosticResult[] suppressors =
 		{
 			ExpectSuppressor(NullableReferenceTypesSuppressor.Rule).WithLocation(8, 29), //field1
 			ExpectSuppressor(NullableReferenceTypesSuppressor.Rule).WithLocation(9, 21), //field2
@@ -77,6 +116,6 @@ public class TestScript : MonoBehaviour
 			.WithLanguageVersion(LanguageVersion.CSharp8)
 			.WithAnalyzerFilter("CS0169");
 
-		await VerifyCSharpDiagnosticAsync(context, test, suppressor);
+		await VerifyCSharpDiagnosticAsync(context, test, suppressors);
 	}
 }

--- a/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/NullableReferenceTypesSuppressorTests.cs
@@ -11,7 +11,10 @@ namespace Microsoft.Unity.Analyzers.Tests;
 
 public class NullableReferenceTypesSuppressorTest : BaseSuppressorVerifierTest<NullableReferenceTypesSuppressor>
 {
-	[Fact] async Task NonUnityClassIsExemptFromSuppressions()
+	public const string WarningFormat = "Non-nullable {0} '{1}' must contain a non-null value when exiting constructor. Consider declaring the {0} as nullable.";
+
+	[Fact]
+	public async Task NonUnityClassIsExemptFromSuppressions()
 	{
 		const string test = @"
 #nullable enable
@@ -41,12 +44,14 @@ namespace Assets.Scripts
 
 		DiagnosticResult[] diagnostics =
 		{
-			DiagnosticResult.CompilerWarning("CS8618")
-				.WithMessage("Non-nullable field 'field1' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.")
+			DiagnosticResult.CompilerWarning(NullableReferenceTypesSuppressor.Rule.SuppressedDiagnosticId)
+				.WithMessageFormat(WarningFormat)
+				.WithArguments("field", "field1")
 				.WithLocation(9, 28), 
 
-			DiagnosticResult.CompilerWarning("CS8618")
-				.WithMessage("Non-nullable property 'property1' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.")
+			DiagnosticResult.CompilerWarning(NullableReferenceTypesSuppressor.Rule.SuppressedDiagnosticId)
+				.WithMessageFormat(WarningFormat)
+				.WithArguments("property", "property1")
 				.WithLocation(11, 28), 
 		};
 
@@ -154,8 +159,9 @@ public class TestScript : MonoBehaviour
 
 			ExpectSuppressor(NullableReferenceTypesSuppressor.Rule).WithLocation(18, 27), //staticField
 
-			DiagnosticResult.CompilerWarning("CS8618")
-				.WithMessage("Non-nullable field 'hiddenField' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.")
+			DiagnosticResult.CompilerWarning(NullableReferenceTypesSuppressor.Rule.SuppressedDiagnosticId)
+				.WithMessageFormat(WarningFormat)
+				.WithArguments("field", "hiddenField")
 				.WithLocation(20, 38), //should throw on public fields that are not shown in the inspector
 
 			ExpectSuppressor(NullableReferenceTypesSuppressor.Rule).WithLocation(21, 38)

--- a/src/Microsoft.Unity.Analyzers/NullableReferenceTypesSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/NullableReferenceTypesSuppressor.cs
@@ -86,13 +86,6 @@ namespace Microsoft.Unity.Analyzers
 				return;
 			}
 
-			var symbol = GetSymbol(diagnostic.Location.SourceTree, declarationSyntax.Declaration.Type, context);
-			if (symbol == null)
-				return;
-
-			if (!symbol.Extends(typeof(UnityEngine.Object)))
-				return;
-
 			var methodBodies = MethodBodies(root)
 				.ToList();
 
@@ -113,13 +106,6 @@ namespace Microsoft.Unity.Analyzers
 
 		private static void AnalyzeProperties(PropertyDeclarationSyntax declarationSyntax, Diagnostic diagnostic, SuppressionAnalysisContext context, SyntaxNode root)
 		{
-			var symbol = GetSymbol(diagnostic.Location.SourceTree, declarationSyntax.Type, context);
-			if (symbol == null)
-				return;
-
-			if (!symbol.Extends(typeof(UnityEngine.Object)))
-				return;
-
 			//check for valid assignments
 			if (IsAssignedTo(declarationSyntax.Identifier.Text, MethodBodies(root)))
 				context.ReportSuppression(Suppression.Create(Rule, diagnostic));

--- a/src/Microsoft.Unity.Analyzers/NullableReferenceTypesSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/NullableReferenceTypesSuppressor.cs
@@ -111,12 +111,6 @@ namespace Microsoft.Unity.Analyzers
 				context.ReportSuppression(Suppression.Create(Rule, diagnostic));
 		}
 
-		private static ITypeSymbol? GetSymbol(CodeAnalysis.SyntaxTree tree, TypeSyntax type, SuppressionAnalysisContext context)
-		{
-			var model = context.GetSemanticModel(tree);
-			return model.GetSymbolInfo(type).Symbol as ITypeSymbol;
-		}
-
 		//analyze if a property is assigned inside a methodbody
 		private static bool IsAssignedTo(string identifier, IEnumerable<SyntaxNode> methodBodies)
 		{


### PR DESCRIPTION
Fixes #197 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Remove `UnityEngine.Object` type checking 

#### Changes proposed in this pull request:
- See the related issue for extra context
- Adding repro as new test
