### PR TITLE
Bump packages and move to NetAnalyzers

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticResult.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticResult.cs
@@ -262,15 +262,15 @@ public readonly struct DiagnosticResult
 		{
 			var location = Spans[0];
 			builder.Append(location.Span.Path == string.Empty ? "?" : location.Span.Path);
-			builder.Append("(");
+			builder.Append('(');
 			builder.Append(location.Span.StartLinePosition.Line + 1);
-			builder.Append(",");
+			builder.Append(',');
 			builder.Append(location.Span.StartLinePosition.Character + 1);
 			if (!location.Options.HasFlag(DiagnosticLocationOptions.IgnoreLength))
 			{
-				builder.Append(",");
+				builder.Append(',');
 				builder.Append(location.Span.EndLinePosition.Line + 1);
-				builder.Append(",");
+				builder.Append(',');
 				builder.Append(location.Span.EndLinePosition.Character + 1);
 			}
 
@@ -278,7 +278,7 @@ public readonly struct DiagnosticResult
 		}
 
 		builder.Append(Severity.ToString().ToLowerInvariant());
-		builder.Append(" ");
+		builder.Append(' ');
 		builder.Append(Id);
 
 		try

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
@@ -314,7 +314,7 @@ public abstract class DiagnosticVerifier
 		var firstInstallationPath = UnityPath.FirstInstallation();
 		string installationFullPath = firstInstallationPath;
 
-		if (UnityPath.OnWindows())
+		if (OperatingSystem.IsWindows())
 		{
 			installationFullPath = Path.Combine(firstInstallationPath, "Editor", "Data");
 

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
@@ -234,8 +234,8 @@ public abstract class DiagnosticVerifier
 			var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, reportSuppressedDiagnostics: true);
 			var specificDiagnosticOptions = compilationOptions.SpecificDiagnosticOptions;
 
-			// Force all tested diagnostics to be enabled
-			foreach (var descriptor in analyzer.SupportedDiagnostics)
+			// Force all tested and related diagnostics to be enabled
+			foreach (var descriptor in analyzers.SelectMany(a => a.SupportedDiagnostics))
 				specificDiagnosticOptions = specificDiagnosticOptions.SetItem(descriptor.Id, ReportDiagnostic.Info);
 
 			var compilationWithAnalyzers = compilation

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/SuppressorVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/SuppressorVerifier.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Unity.Analyzers.Tests;
 [Flags]
 public enum SuppressorVerifierAnalyzers
 {
-	CodeStyle = 1,
-	FxCop = 2
+	CodeStyle = 1,  // CSxxxx, IDExxxx
+	CodeQuality = 2 // CAxxxx
 }
 
 public abstract class SuppressorVerifier : DiagnosticVerifier
@@ -54,10 +54,10 @@ public abstract class SuppressorVerifier : DiagnosticVerifier
 			analyzers.AddRange(LoadAnalyzers("Microsoft.CodeAnalysis.CSharp.CodeStyle.dll"));
 		}
 
-		if (SuppressorVerifierAnalyzers.HasFlag(SuppressorVerifierAnalyzers.FxCop))
+		if (SuppressorVerifierAnalyzers.HasFlag(SuppressorVerifierAnalyzers.CodeQuality))
 		{
-			analyzers.AddRange(LoadAnalyzers("Microsoft.CodeQuality.Analyzers.dll"));
-			analyzers.AddRange(LoadAnalyzers("Microsoft.CodeQuality.CSharp.Analyzers.dll"));
+			analyzers.AddRange(LoadAnalyzers("Microsoft.CodeAnalysis.NetAnalyzers.dll"));
+			analyzers.AddRange(LoadAnalyzers("Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll"));
 		}
 
 		return analyzers

--- a/src/Microsoft.Unity.Analyzers.Tests/MessageCodeQualitySuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/MessageCodeQualitySuppressorTests.cs
@@ -8,10 +8,10 @@ using Xunit;
 
 namespace Microsoft.Unity.Analyzers.Tests;
 
-public class MessageFxCopSuppressorTests : BaseSuppressorVerifierTest<MessageSuppressor>
+public class MessageCodeQualitySuppressorTests : BaseSuppressorVerifierTest<MessageSuppressor>
 {
-	// Only load FxCop analyzers for those tests
-	protected override SuppressorVerifierAnalyzers SuppressorVerifierAnalyzers => SuppressorVerifierAnalyzers.FxCop;
+	// Only load CodeQuality analyzers for those tests
+	protected override SuppressorVerifierAnalyzers SuppressorVerifierAnalyzers => SuppressorVerifierAnalyzers.CodeQuality;
 
 	[Fact]
 	public async Task StaticMethodSuppressed()
@@ -27,7 +27,7 @@ public class TestScript : MonoBehaviour
 }
 ";
 
-		var suppressor = ExpectSuppressor(MessageSuppressor.MethodFxCopRule)
+		var suppressor = ExpectSuppressor(MessageSuppressor.MethodCodeQualityRule)
 			.WithLocation(6, 18);
 
 		await VerifyCSharpDiagnosticAsync(test, suppressor);
@@ -48,9 +48,11 @@ public class TestScript : MonoBehaviour
 }
 ";
 
-		var suppressor = ExpectSuppressor(MessageSuppressor.ParameterFxCopRule)
-			.WithLocation(6, 35);
+		// This CA1801 rule has been deprecated in favor of IDE0060
+		// Disable this, as the current NetAnalyzers will not trigger a diagnostic anymore
+		// var suppressor = ExpectSuppressor(MessageSuppressor.ParameterCodeQualityRule)
+		//   .WithLocation(6, 35);
 
-		await VerifyCSharpDiagnosticAsync(test, suppressor);
+		await VerifyCSharpDiagnosticAsync(test /*, suppressor*/);
 	}
 }

--- a/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
+++ b/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
@@ -8,14 +8,14 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.3.1" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.0.1" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.1.0" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.2" />    
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64" PrivateAssets="all" />	
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.1.46" PrivateAssets="all" />	
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
+++ b/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.3.1" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.1.0" GeneratePathProperty="true" />
@@ -27,7 +27,7 @@
       <Visible>False</Visible>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>  
-    <None Include="$(PkgMicrosoft_CodeQuality_Analyzers)\analyzers\dotnet\cs\*.dll">
+    <None Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)\analyzers\dotnet\cs\*.dll">
       <Visible>False</Visible>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>  

--- a/src/Microsoft.Unity.Analyzers.Tests/SerializeFieldCodeQualitySuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/SerializeFieldCodeQualitySuppressorTests.cs
@@ -8,10 +8,10 @@ using Xunit;
 
 namespace Microsoft.Unity.Analyzers.Tests;
 
-public class SerializeFieldFxCopSuppressorTests : BaseSuppressorVerifierTest<SerializeFieldSuppressor>
+public class SerializeFieldCodeQualitySuppressorTests : BaseSuppressorVerifierTest<SerializeFieldSuppressor>
 {
-	// Only load FxCop analyzers for those tests
-	protected override SuppressorVerifierAnalyzers SuppressorVerifierAnalyzers => SuppressorVerifierAnalyzers.FxCop;
+	// Only load CodeQuality analyzers for those tests
+	protected override SuppressorVerifierAnalyzers SuppressorVerifierAnalyzers => SuppressorVerifierAnalyzers.CodeQuality;
 
 	[Fact]
 	public async Task PrivateFieldWithAttributeUnusedSuppressed()
@@ -26,7 +26,7 @@ class Camera : MonoBehaviour
 }
 ";
 
-		var suppressor = ExpectSuppressor(SerializeFieldSuppressor.UnusedFxCopRule)
+		var suppressor = ExpectSuppressor(SerializeFieldSuppressor.UnusedCodeQualityRule)
 			.WithLocation(7, 12);
 
 		await VerifyCSharpDiagnosticAsync(test, suppressor);

--- a/src/Microsoft.Unity.Analyzers.Tests/UnityPath.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityPath.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using Microsoft.Win32;
 using Xunit;
 
@@ -23,7 +24,7 @@ internal static class UnityPath
 
 	static UnityPath()
 	{
-		if (OnWindows())
+		if (OperatingSystem.IsWindows())
 		{
 			RegisterRegistryInstallations();
 		}
@@ -51,6 +52,7 @@ internal static class UnityPath
 		RegisterUnityInstallation("/Applications/Unity/Unity.app/Contents");
 	}
 
+	[SupportedOSPlatform("windows")]
 	private static void RegisterRegistryInstallations()
 	{
 		var hive = Registry.CurrentUser;
@@ -91,15 +93,5 @@ internal static class UnityPath
 	{
 		if (!string.IsNullOrEmpty(path) && Directory.Exists(path))
 			UnityInstallations.Add(path);
-	}
-
-	internal static bool OnWindows()
-	{
-		return Environment.OSVersion.Platform switch
-		{
-			PlatformID.Win32NT => true,
-			PlatformID.Win32Windows => true,
-			_ => false
-		};
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/MessageSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/MessageSuppressor.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Unity.Analyzers
 			suppressedDiagnosticId: "IDE0051",
 			justification: Strings.MessageSuppressorJustification);
 
-		internal static readonly SuppressionDescriptor MethodFxCopRule = new(
+		internal static readonly SuppressionDescriptor MethodCodeQualityRule = new(
 			id: "USP0014",
 			suppressedDiagnosticId: "CA1822",
 			justification: Strings.MessageSuppressorJustification);
@@ -30,12 +30,13 @@ namespace Microsoft.Unity.Analyzers
 			suppressedDiagnosticId: "IDE0060",
 			justification: Strings.MessageSuppressorJustification);
 
-		internal static readonly SuppressionDescriptor ParameterFxCopRule = new(
+		// This CA1801 rule has been deprecated in favor of IDE0060, keep it for legacy compatibility
+		internal static readonly SuppressionDescriptor ParameterCodeQualityRule = new(
 			id: "USP0015",
 			suppressedDiagnosticId: "CA1801",
 			justification: Strings.MessageSuppressorJustification);
 
-		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(MethodRule, MethodFxCopRule, ParameterRule, ParameterFxCopRule);
+		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(MethodRule, MethodCodeQualityRule, ParameterRule, ParameterCodeQualityRule);
 
 		public override void ReportSuppressions(SuppressionAnalysisContext context)
 		{

--- a/src/Microsoft.Unity.Analyzers/Microsoft.Unity.Analyzers.csproj
+++ b/src/Microsoft.Unity.Analyzers/Microsoft.Unity.Analyzers.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.1.46" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Unity.Analyzers/SerializeFieldSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/SerializeFieldSuppressor.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Unity.Analyzers
 			suppressedDiagnosticId: "IDE0051",
 			justification: Strings.UnusedSerializeFieldSuppressorJustification);
 
-		internal static readonly SuppressionDescriptor UnusedFxCopRule = new(
+		internal static readonly SuppressionDescriptor UnusedCodeQualityRule = new(
 			id: "USP0013",
 			suppressedDiagnosticId: "CA1823",
 			justification: Strings.UnusedSerializeFieldSuppressorJustification);
@@ -36,7 +36,7 @@ namespace Microsoft.Unity.Analyzers
 			suppressedDiagnosticId: "CS0649",
 			justification: Strings.NeverAssignedSerializeFieldSuppressorJustification);
 
-		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(ReadonlyRule, UnusedRule, UnusedFxCopRule, NeverAssignedRule);
+		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(ReadonlyRule, UnusedRule, UnusedCodeQualityRule, NeverAssignedRule);
 
 		public override void ReportSuppressions(SuppressionAnalysisContext context)
 		{


### PR DESCRIPTION
#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;

#### Short description of what this resolves:
Bump package versions and use `Microsoft.CodeAnalysis.NetAnalyzers` instead of the now deprecated `Microsoft.CodeQuality.Analyzers`. Fix new warnings.

See the guidance here:
https://github.com/dotnet/roslyn-analyzers#main-analyzers
