### PR TITLE
Always reference netstandard facades

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
@@ -343,6 +343,9 @@ public abstract class DiagnosticVerifier
 		var monolib = Path.Combine(installationFullPath, "MonoBleedingEdge", "lib", "mono", "4.7.1-api");
 		yield return Path.Combine(monolib, "mscorlib.dll");
 		yield return Path.Combine(monolib, "system.dll");
+
+		var facades = Path.Combine(monolib, "Facades");
+		yield return Path.Combine(facades, "netstandard.dll");
 	}
 
 	private static Project CreateProject(AnalyzerVerificationContext context, string[] sources)


### PR DESCRIPTION
Fixes #207 

#### Checklist
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] I have added tests that prove my fix is effective or that my feature works ;

#### Short description of what this resolves:
Always reference netstandard facades

Tested with:
- 2020.3.26f1 LTS
- 2021.2.13f1
- 2022.1.0b9 (mandatory in this case)
