### PR TITLE
Add `USP0018`, ThrowExpressionSuppressor

### DIFF
--- a/doc/USP0001.md
+++ b/doc/USP0001.md
@@ -28,4 +28,4 @@ Under normal circumstances, `return a != null ? a : b` can be simplified to `ret
 
 ## Why do we suppress this diagnostic?
 
-Unity has overridden the == operator for `UnityEngine.Object`. If you use the == operator to compare a `UnityEngine.Object` to null, it will return true if the `UnityEngine.Object` is destroyed, even if the object itself isn't actually null. The ?? operator cannot be overridden in this way, and therefore behaves inconsistently with the == operator, because it checks for null in a different way.
+Unity has overridden the `==` operator for `UnityEngine.Object`. If you use the `==` operator to compare a `UnityEngine.Object` to null, it will return true if the `UnityEngine.Object` is destroyed, even if the object itself isn't actually null. The `??` operator cannot be overridden in this way, and therefore behaves inconsistently with the `==` operator, because it checks for null in a different way.

--- a/doc/USP0002.md
+++ b/doc/USP0002.md
@@ -25,4 +25,4 @@ Under normal circumstances, `return transform != null ? transform : null` can be
 
 ## Why do we suppress this diagnostic?
 
-Unity has overridden the == operator for `UnityEngine.Object`. If you use the == operator to compare a `UnityEngine.Object` to null, it will return true if the `UnityEngine.Object` is destroyed, even if the object itself isn't actually null. Null propagation cannot be overridden in this way, and therefore behaves inconsistently with the == operator, because it checks for null in a different way.
+Unity has overridden the `==` operator for `UnityEngine.Object`. If you use the `==` operator to compare a `UnityEngine.Object` to null, it will return true if the `UnityEngine.Object` is destroyed, even if the object itself isn't actually null. Null propagation cannot be overridden in this way, and therefore behaves inconsistently with the == operator, because it checks for null in a different way.

--- a/doc/USP0015.md
+++ b/doc/USP0015.md
@@ -21,8 +21,8 @@ class Camera : MonoBehaviour
 
 ## Why is the diagnostic reported?
 
-FxCop does not detect that you've used `c`, and under normal circumstances, it would be reasonable to remove the unused parameter.
+The Code Quality analyzer does not detect that you've used `c`, and under normal circumstances, it would be reasonable to remove the unused parameter.
 
 ## Why do we suppress this diagnostic?
 
-FxCop doesn't realize this is a Unity message, and therefore has no way of determining that it needs to have a specific signature to function correctly.
+The Code Quality analyzer doesn't realize this is a Unity message, and therefore has no way of determining that it needs to have a specific signature to function correctly.

--- a/doc/USP0016.md
+++ b/doc/USP0016.md
@@ -56,7 +56,7 @@ public class Test : Monobehaviour
 ```
 ## Why is the diagnostic reported?
 
-The IDE cannot detect that specific members are initialized by the Unity runtime.
+The Code Style analyzer cannot detect that specific members are initialized by the Unity runtime.
 
 ## Why do we suppress this diagnostic?
 

--- a/doc/USP0017.md
+++ b/doc/USP0017.md
@@ -30,4 +30,4 @@ Under normal circumstances, `return a ?? (a = b)` can be simplified to `return a
 
 ## Why do we suppress this diagnostic?
 
-Unity has overridden the == operator for `UnityEngine.Object`. If you use the ??= operator with those objects, it will not behave as expected because it checks for null in a different way.
+Unity has overridden the `==` operator for `UnityEngine.Object`. If you use the `??=` operator with those objects, it will not behave as expected because it checks for null in a different way.

--- a/doc/USP0018.md
+++ b/doc/USP0018.md
@@ -1,0 +1,32 @@
+# USP0018 Unity objects should not be used with throw expressions
+
+`UnityEngine.Object` should not be used with `throw` expressions.
+
+## Suppressed Diagnostic ID
+
+IDE0016 - Use throw expression
+
+## Examples of code that produces a suppressed diagnostic
+```csharp
+using System;
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public MonoBehaviour value;
+    public void Method(MonoBehaviour value) {
+        if (value == null)
+            throw new ArgumentNullException(nameof(value));
+
+        this.value = value;
+    }
+}
+```
+
+## Why is the diagnostic reported?
+
+Under normal circumstances, this code can be simplified to `this.value = value ?? throw new ArgumentNullException(nameof(value))`.
+
+## Why do we suppress this diagnostic?
+
+Unity has overridden the `==` operator for `UnityEngine.Object`. If you use `??` operator with those objects, it will not behave as expected because it checks for null in a different way.

--- a/doc/index.md
+++ b/doc/index.md
@@ -50,3 +50,4 @@ ID | Suppressed ID | Justification
 [USP0015](USP0015.md) | CA1801 | The Unity runtime invokes Unity messages
 [USP0016](USP0016.md) | CS8618 | Initialization detection with nullable reference types
 [USP0017](USP0017.md) | IDE0074 | Unity objects should not use coalescing assignment
+[USP0018](USP0018.md) | IDE0016 | Unity objects should not be used with throw expressions

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/AnalyzerOptionsProvider.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/AnalyzerOptionsProvider.cs
@@ -60,6 +60,7 @@ internal class AnalyzerConfigOptionsLookup : AnalyzerConfigOptions
 		_default.Add("dotnet_style_null_propagation", "true");
 		_default.Add("dotnet_style_readonly_field", "true:suggestion");
 		_default.Add("dotnet_style_prefer_compound_assignment", "true");
+		_default.Add("csharp_style_throw_expression", "true");
 
 		_default.Add("csharp_style_unused_value_expression_statement_preference", "discard_variable");
 		_default.Add("csharp_style_unused_value_assignment_preference", "discard_variable");

--- a/src/Microsoft.Unity.Analyzers.Tests/ThrowExpressionSuppressorTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ThrowExpressionSuppressorTests.cs
@@ -1,0 +1,94 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests
+{
+	public class ThrowExpressionSuppressorTests : BaseSuppressorVerifierTest<ThrowExpressionSuppressor>
+	{
+		protected override SuppressorVerifierAnalyzers SuppressorVerifierAnalyzers => SuppressorVerifierAnalyzers.CodeQuality | SuppressorVerifierAnalyzers.CodeStyle;
+
+		[Fact]
+		public async Task SuppressThrowExpressionWithUnityObjects()
+		{
+			const string test = @"
+using System;
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public MonoBehaviour value;
+    public void Method(MonoBehaviour value) {
+        if (value == null)
+            throw new ArgumentNullException(nameof(value));
+
+        this.value = value;
+    }
+}
+";
+
+			var suppressor = ExpectSuppressor(ThrowExpressionSuppressor.Rule)
+				.WithLocation(10, 13);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+
+		[Fact]
+		public async Task SuppressThrowExpressionWithUnityObjectsCodeBlock()
+		{
+			const string test = @"
+using System;
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public MonoBehaviour value;
+    public void Method(MonoBehaviour value) {
+        if (value == null) {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        this.value = value;
+    }
+}
+";
+
+			var suppressor = ExpectSuppressor(ThrowExpressionSuppressor.Rule)
+				.WithLocation(10, 13);
+
+			await VerifyCSharpDiagnosticAsync(test, suppressor);
+		}
+
+		[Fact]
+		public async Task DoNotSuppressThrowExpressionWithNonUnityObjects()
+		{
+			const string test = @"
+using System;
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public object value;
+    public void Method(object value) {
+        if (value == null)
+            throw new ArgumentNullException(nameof(value));
+
+        this.value = value;
+    }
+}
+";
+
+			var diagnostic = DiagnosticResult.CompilerWarning(ThrowExpressionSuppressor.Rule.SuppressedDiagnosticId)
+				.WithSeverity(DiagnosticSeverity.Info)
+				.WithMessage("Null check can be simplified")
+				.WithLocation(10, 13); 
+
+			await VerifyCSharpDiagnosticAsync(test, diagnostic);
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -808,6 +808,15 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Do not use Throw expressions with Unity objects..
+        /// </summary>
+        internal static string ThrowExpressionSuppressorJustification {
+            get {
+                return ResourceManager.GetString("ThrowExpressionSuppressorJustification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use TryGetComponent instead.
         /// </summary>
         internal static string TryGetComponentCodeFixTitle {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -483,4 +483,7 @@
   <data name="TryGetComponentDiagnosticTitle" xml:space="preserve">
     <value>GetComponent always allocates</value>
   </data>
+  <data name="ThrowExpressionSuppressorJustification" xml:space="preserve">
+    <value>Do not use Throw expressions with Unity objects.</value>
+  </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/ThrowExpressionSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/ThrowExpressionSuppressor.cs
@@ -1,0 +1,61 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Unity.Analyzers.Resources;
+
+namespace Microsoft.Unity.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class ThrowExpressionSuppressor : DiagnosticSuppressor
+	{
+		internal static readonly SuppressionDescriptor Rule = new(
+			id: "USP0018",
+			suppressedDiagnosticId: "IDE0016",
+			justification: Strings.ThrowExpressionSuppressorJustification);
+
+		public override void ReportSuppressions(SuppressionAnalysisContext context)
+		{
+			foreach (var diagnostic in context.ReportedDiagnostics)
+			{
+				AnalyzeDiagnostic(diagnostic, context);
+			}
+		}
+
+		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(Rule);
+
+		private static void AnalyzeDiagnostic(Diagnostic diagnostic, SuppressionAnalysisContext context)
+		{
+			var node = context.GetSuppressibleNode<SyntaxNode>(diagnostic);
+			if (node is not ThrowStatementSyntax)
+				return;
+
+			var ifStatement = node
+				.Ancestors()
+				.OfType<IfStatementSyntax>()
+				.FirstOrDefault();
+
+			if (ifStatement?.Condition is not BinaryExpressionSyntax binaryExpression)
+				return;
+
+			var model = context.GetSemanticModel(diagnostic.Location.SourceTree);
+			if (model == null)
+				return;
+
+			if (ShouldReportSuppression(binaryExpression.Left, model) || ShouldReportSuppression(binaryExpression.Right, model))
+				context.ReportSuppression(Suppression.Create(Rule, diagnostic));
+		}
+
+		private static bool ShouldReportSuppression(ExpressionSyntax expression, SemanticModel model)
+		{
+			var type = model.GetTypeInfo(expression);
+			return type.Type?.Extends(typeof(UnityEngine.Object)) ?? false;
+		}
+	}
+}

--- a/src/new-analyzer/SuppressorDiagnosticBuilder.cs
+++ b/src/new-analyzer/SuppressorDiagnosticBuilder.cs
@@ -75,7 +75,7 @@ using Xunit;
 
 namespace Microsoft.Unity.Analyzers.Tests
 {
-	public class $(DiagnosticName)Tests : BaseSuppressorVerifierTest<UnusedMethodSuppressor>
+	public class $(DiagnosticName)Tests : BaseSuppressorVerifierTest<$(DiagnosticName)>
 	{
 		[Fact]
 		public async Task Test()


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #204 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Add a new `USP0018` suppressor for throw expressions on types extending `UnityEngine.Object`.

#### Changes proposed in this pull request:
- Added suppressor and documentation
- Fixed the default suppressor template always using `UnusedMethodSuppressor` instead of the newly created suppressor. 
- Fixed non-catched exceptions in tests, regarding missing analyzer options. (needed here for `csharp_style_throw_expression`)
