### PR TITLE
Bump Unity to 2021.3.1f1 LTS

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -11,8 +11,8 @@ on:
     - release/*
 
 env:
-  UNITY_HASH: f5400f52e03f
-  UNITY_FULL_VERSION: 2020.3.28f1
+  UNITY_HASH: 3b70a0754835
+  UNITY_FULL_VERSION: 2021.3.1f1
   
 jobs:
   macos:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -11,8 +11,8 @@ on:
     - release/*
 
 env:
-  UNITY_HASH: f5400f52e03f
-  UNITY_FULL_VERSION: 2020.3.28f1
+  UNITY_HASH: 3b70a0754835
+  UNITY_FULL_VERSION: 2021.3.1f1
 
 # Tracing builds with CodeQL is currently not supported on Windows 11 and Windows Server 2022. so use windows-2019 instead of windows-latest
 


### PR DESCRIPTION
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;

#### Short description of what this resolves:
Bump Unity to 2021.3.1f1 LTS