### PR TITLE
Add UNT0027 Diagnostic/CodeFix

### DIFF
--- a/doc/UNT0027.md
+++ b/doc/UNT0027.md
@@ -1,0 +1,35 @@
+# UNT0027 Do not call PropertyDrawer.OnGUI()
+
+You can derive `PropertyDrawer` to create custom drawers. But default implementation for `OnGUI(Rect position, SerializedProperty property, GUIContent label)` will display `no GUI implemented` in the Unity inspector.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using UnityEngine;
+using UnityEditor;
+
+class MyDrawer : PropertyDrawer
+{
+	public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+		base.OnGUI(position, property, label);
+	}
+}
+```
+
+## Solution
+
+Remove `base.OnGUI()` :
+
+```csharp
+using UnityEngine;
+using UnityEditor;
+
+class MyDrawer : PropertyDrawer
+{
+	public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+	    // code your own OnGUI here, do not use base.OnGUI()
+	}
+}
+```
+
+A code fix is offered for this diagnostic to automatically apply this change.

--- a/doc/index.md
+++ b/doc/index.md
@@ -28,6 +28,7 @@ ID | Title | Category
 [UNT0024](UNT0024.md) | Give priority to scalar calculations over vector calculations | Performance
 [UNT0025](UNT0025.md) | Input.GetKey overloads with KeyCode argument | Correctness
 [UNT0026](UNT0026.md) | GetComponent always allocates | Performance
+[UNT0027](UNT0027.md) | Do not call PropertyDrawer.OnGUI() | Correctness
 
 # Diagnostic Suppressors
 

--- a/src/Microsoft.Unity.Analyzers.Tests/PropertyDrawerOnGUITests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/PropertyDrawerOnGUITests.cs
@@ -1,0 +1,126 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests;
+
+public class PropertyDrawerOnGUITests : BaseCodeFixVerifierTest<PropertyDrawerOnGUIAnalyzer, PropertyDrawerOnGUICodeFix>
+{
+	[Fact]
+	public async Task TestOnGUI()
+	{
+		const string test = @"
+using UnityEditor;
+
+class MyDrawer : PropertyDrawer
+{
+	public void Foo() {
+		OnGUI(default, default, default);
+	}
+}
+";
+
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(7, 3);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEditor;
+
+class MyDrawer : PropertyDrawer
+{
+	public void Foo() {
+	}
+}
+";
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task TestOnGUIOverride()
+	{
+		const string test = @"
+using UnityEngine;
+using UnityEditor;
+
+class DerivedDrawer : PropertyDrawer
+{
+	public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+	}
+}
+
+class MyDrawer : DerivedDrawer
+{
+	public void Foo() {
+		OnGUI(default, default, default);
+	}
+}
+";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task TestBaseOnGUI()
+	{
+		const string test = @"
+using UnityEngine;
+using UnityEditor;
+
+class MyDrawer : PropertyDrawer
+{
+	public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+		base.OnGUI(position, property, label);
+	}
+}
+";
+
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(8, 3);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+using UnityEditor;
+
+class MyDrawer : PropertyDrawer
+{
+	public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+	}
+}
+";
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task TestBaseOnGUIOverride()
+	{
+		const string test = @"
+using UnityEngine;
+using UnityEditor;
+
+class DerivedDrawer : PropertyDrawer
+{
+	public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+	}
+}
+
+class MyDrawer : DerivedDrawer
+{
+	public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+		base.OnGUI(position, property, label);
+	}
+}
+";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/PropertyDrawerOnGUI.cs
+++ b/src/Microsoft.Unity.Analyzers/PropertyDrawerOnGUI.cs
@@ -1,0 +1,90 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Unity.Analyzers.Resources;
+
+namespace Microsoft.Unity.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class PropertyDrawerOnGUIAnalyzer : DiagnosticAnalyzer
+{
+	internal static readonly DiagnosticDescriptor Rule = new(
+		id: "UNT0027",
+		title: Strings.PropertyDrawerOnGUIDiagnosticTitle,
+		messageFormat: Strings.PropertyDrawerOnGUIDiagnosticMessageFormat,
+		category: DiagnosticCategory.Correctness,
+		defaultSeverity: DiagnosticSeverity.Info,
+		isEnabledByDefault: true,
+		description: Strings.PropertyDrawerOnGUIDiagnosticDescription);
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+	public override void Initialize(AnalysisContext context)
+	{
+		context.EnableConcurrentExecution();
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+		context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+	}
+
+	private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+	{
+		var invocation = (InvocationExpressionSyntax)context.Node;
+		var name = invocation.GetMethodNameSyntax();
+		if (name is not {Identifier.Text: "OnGUI"})
+			return;
+
+		var symbol = context.SemanticModel.GetSymbolInfo(invocation);
+
+		if (symbol.Symbol is not IMethodSymbol method)
+			return;
+
+		if (method.ContainingType.ToDisplayString() != "UnityEditor.PropertyDrawer")
+			return;
+
+		context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), invocation));
+	}
+}
+
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+public class PropertyDrawerOnGUICodeFix : CodeFixProvider
+{
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(PropertyDrawerOnGUIAnalyzer.Rule.Id);
+
+	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+	{
+		var invocation = await context.GetFixableNodeAsync<InvocationExpressionSyntax>();
+		if (invocation == null)
+			return;
+
+		context.RegisterCodeFix(
+			CodeAction.Create(
+				Strings.PropertyDrawerOnGUICodeFixTitle,
+				ct => RemoveInvocationAsync(context.Document, invocation, ct),
+				invocation.ToFullString()),
+			context.Diagnostics);
+	}
+
+	private static async Task<Document> RemoveInvocationAsync(Document document, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
+	{
+		var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+		var newRoot = root.RemoveNode(invocation.Parent, SyntaxRemoveOptions.KeepNoTrivia);
+		if (newRoot == null)
+			return document;
+
+		return document.WithSyntaxRoot(newRoot);
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -637,6 +637,42 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove PropertyDrawer.OnGUI() call.
+        /// </summary>
+        internal static string PropertyDrawerOnGUICodeFixTitle {
+            get {
+                return ResourceManager.GetString("PropertyDrawerOnGUICodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default implementation for PropertyDrawer.OnGUI() will display &quot;no GUI implemented&quot; in the inspector..
+        /// </summary>
+        internal static string PropertyDrawerOnGUIDiagnosticDescription {
+            get {
+                return ResourceManager.GetString("PropertyDrawerOnGUIDiagnosticDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PropertyDrawer.OnGUI() will display &quot;no GUI implemented&quot; in the inspector..
+        /// </summary>
+        internal static string PropertyDrawerOnGUIDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("PropertyDrawerOnGUIDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not call PropertyDrawer.OnGUI().
+        /// </summary>
+        internal static string PropertyDrawerOnGUIDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("PropertyDrawerOnGUIDiagnosticTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Make Unity message protected.
         /// </summary>
         internal static string ProtectedUnityMessageCodeFixTitle {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -489,4 +489,16 @@
   <data name="ImplicitUsageAttributeSuppressorJustification" xml:space="preserve">
     <value>Don't flag private methods decorated with PreserveAttribute or UsedImplicitlyAttribute as unused.</value>
   </data>
+  <data name="PropertyDrawerOnGUICodeFixTitle" xml:space="preserve">
+    <value>Remove PropertyDrawer.OnGUI() call</value>
+  </data>
+  <data name="PropertyDrawerOnGUIDiagnosticDescription" xml:space="preserve">
+    <value>Default implementation for PropertyDrawer.OnGUI() will display "no GUI implemented" in the inspector.</value>
+  </data>
+  <data name="PropertyDrawerOnGUIDiagnosticMessageFormat" xml:space="preserve">
+    <value>PropertyDrawer.OnGUI() will display "no GUI implemented" in the inspector.</value>
+  </data>
+  <data name="PropertyDrawerOnGUIDiagnosticTitle" xml:space="preserve">
+    <value>Do not call PropertyDrawer.OnGUI()</value>
+  </data>
 </root>


### PR DESCRIPTION
#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Prevent/fix call to default PropertyDrawer.OnGUI() implementation. 

See for more context:
https://answers.unity.com/questions/745266/property-drawer-no-gui-implemented-error-in-editor.html
https://github.com/Unity-Technologies/UnityCsReference/blob/master/Editor/Mono/ScriptAttributeGUI/PropertyDrawer.cs#L35
