### PR TITLE
Add UNT0028 - Use non-allocating physics APIs

### DIFF
--- a/doc/UNT0028.md
+++ b/doc/UNT0028.md
@@ -1,0 +1,24 @@
+# UNT0028 Use non-allocating physics APIs
+
+Non-allocating versions of Physics query APIs have been introduced. You can replace `RaycastAll` calls with `RaycastNonAlloc`, `SphereCastAll` calls with `SphereCastNonAlloc`, and so on.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    void Update() {
+        var result = Physics.RaycastAll(Vector3.zero, Vector3.zero);
+        // ...
+        result = Physics.RaycastAll(Vector3.zero, Vector3.zero);
+    }
+}
+```
+
+## Solution
+
+Instead of allocating a new array for each call, you can reuse a pre-allocated array to store the results. This will improve performance, especially for frequent calls.
+
+No automatic code fix is available for this diagnostic.

--- a/doc/index.md
+++ b/doc/index.md
@@ -29,6 +29,7 @@ ID | Title | Category
 [UNT0025](UNT0025.md) | Input.GetKey overloads with KeyCode argument | Correctness
 [UNT0026](UNT0026.md) | GetComponent always allocates | Performance
 [UNT0027](UNT0027.md) | Do not call PropertyDrawer.OnGUI() | Correctness
+[UNT0028](UNT0028.md) | Use non-allocating physics APIs | Performance
 
 # Diagnostic Suppressors
 

--- a/src/Microsoft.Unity.Analyzers.Tests/PhysicsAllocMethodUsageTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/PhysicsAllocMethodUsageTests.cs
@@ -1,0 +1,73 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests;
+
+public class PhysicsAllocMethodUsageTests : BaseDiagnosticVerifierTest<PhysicsAllocMethodUsageAnalyzer>
+{
+	[Fact]
+	public async Task TestRaycastAll()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    void Update() {
+        var result = Physics.RaycastAll(Vector3.zero, Vector3.zero);
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(7, 30)
+			.WithMessage("Compared to 'RaycastAll', 'RaycastNonAlloc' is not allocating memory.");
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+	}
+
+	[Fact]
+	public async Task TestOverlapBox()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    void Update() {
+        var result = Physics.OverlapBox(Vector3.zero, Vector3.zero);
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(7, 30)
+			.WithMessage("Compared to 'OverlapBox', 'OverlapBoxNonAlloc' is not allocating memory.");
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+	}
+
+	[Fact]
+	public async Task TestOverlapBoxNonAlloc()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    void Update() {
+		var results = new Collider[3];
+        Physics.OverlapBoxNonAlloc(Vector3.zero, Vector3.zero, results);
+    }
+}
+";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+}

--- a/src/Microsoft.Unity.Analyzers/MethodUsage.cs
+++ b/src/Microsoft.Unity.Analyzers/MethodUsage.cs
@@ -73,6 +73,11 @@ public abstract class MethodUsageAnalyzer<T> : DiagnosticAnalyzer where T : Meth
 		if (!IsReportable(method))
 			return;
 
+		ReportDiagnostic(context, member, method);
+	}
+
+	protected virtual void ReportDiagnostic(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax member, IMethodSymbol method)
+	{
 		context.ReportDiagnostic(Diagnostic.Create(SupportedDiagnostics.First(), member.Name.GetLocation(), method.Name));
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/PhysicsAllocMethodUsage.cs
+++ b/src/Microsoft.Unity.Analyzers/PhysicsAllocMethodUsage.cs
@@ -1,0 +1,46 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Unity.Analyzers.Resources;
+using UnityEngine;
+
+namespace Microsoft.Unity.Analyzers;
+
+public class PhysicsAllocMethodUsageAttribute : MethodUsageAttribute
+{
+}
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class PhysicsAllocMethodUsageAnalyzer : MethodUsageAnalyzer<PhysicsAllocMethodUsageAttribute>
+{
+	internal static readonly DiagnosticDescriptor Rule = new(
+		id: "UNT0028",
+		title: Strings.PhysicsAllocMethodUsageDiagnosticTitle,
+		messageFormat: Strings.PhysicsAllocMethodUsageDiagnosticMessageFormat,
+		category: DiagnosticCategory.Performance,
+		defaultSeverity: DiagnosticSeverity.Info,
+		isEnabledByDefault: true,
+		description: Strings.PhysicsAllocMethodUsageDiagnosticDescription);
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+	protected override IEnumerable<MethodInfo> CollectMethods()
+	{
+		return CollectMethods(typeof(Physics));
+	}
+
+	protected override void ReportDiagnostic(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax member, IMethodSymbol method)
+	{
+		var candidate = method.Name.Replace("All", string.Empty) + "NonAlloc";
+		context.ReportDiagnostic(Diagnostic.Create(Rule, member.Name.GetLocation(), method.Name, candidate));
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -637,6 +637,33 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Avoid using allocating versions of Physics functions..
+        /// </summary>
+        internal static string PhysicsAllocMethodUsageDiagnosticDescription {
+            get {
+                return ResourceManager.GetString("PhysicsAllocMethodUsageDiagnosticDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Compared to &apos;{0}&apos;, &apos;{1}&apos; is not allocating memory..
+        /// </summary>
+        internal static string PhysicsAllocMethodUsageDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("PhysicsAllocMethodUsageDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use non-allocating physics APIs.
+        /// </summary>
+        internal static string PhysicsAllocMethodUsageDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("PhysicsAllocMethodUsageDiagnosticTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove PropertyDrawer.OnGUI() call.
         /// </summary>
         internal static string PropertyDrawerOnGUICodeFixTitle {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -501,4 +501,13 @@
   <data name="PropertyDrawerOnGUIDiagnosticTitle" xml:space="preserve">
     <value>Do not call PropertyDrawer.OnGUI()</value>
   </data>
+  <data name="PhysicsAllocMethodUsageDiagnosticDescription" xml:space="preserve">
+    <value>Avoid using allocating versions of Physics functions.</value>
+  </data>
+  <data name="PhysicsAllocMethodUsageDiagnosticMessageFormat" xml:space="preserve">
+    <value>Compared to '{0}', '{1}' is not allocating memory.</value>
+  </data>
+  <data name="PhysicsAllocMethodUsageDiagnosticTitle" xml:space="preserve">
+    <value>Use non-allocating physics APIs</value>
+  </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/UnityStubs.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityStubs.cs
@@ -555,6 +555,48 @@ namespace UnityEngine
 		[KeyTextAttribute("joystick 8 button 18")] Joystick8Button18 = 508,
 		[KeyTextAttribute("joystick 8 button 19")] Joystick8Button19 = 509
 	}
+
+	class RaycastHit { }
+	enum QueryTriggerInteraction { }
+	struct Quaternion { }
+	struct Ray { }
+
+	class Physics
+	{
+		[PhysicsAllocMethodUsage] static RaycastHit[] RaycastAll(Vector3 origin, Vector3 direction, float maxDistance, int layerMask, QueryTriggerInteraction queryTriggerInteraction) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] RaycastAll(Vector3 origin, Vector3 direction, float maxDistance, int layerMask) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] RaycastAll(Vector3 origin, Vector3 direction, float maxDistance) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] RaycastAll(Vector3 origin, Vector3 direction) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] RaycastAll(Ray ray, float maxDistance, int layerMask, QueryTriggerInteraction queryTriggerInteraction) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] RaycastAll(Ray ray, float maxDistance, int layerMask) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] RaycastAll(Ray ray, float maxDistance) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] RaycastAll(Ray ray) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] CapsuleCastAll(Vector3 point1, Vector3 point2, float radius, Vector3 direction, float maxDistance, int layerMask, QueryTriggerInteraction queryTriggerInteraction) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] CapsuleCastAll(Vector3 point1, Vector3 point2, float radius, Vector3 direction, float maxDistance, int layerMask) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] CapsuleCastAll(Vector3 point1, Vector3 point2, float radius, Vector3 direction, float maxDistance) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] CapsuleCastAll(Vector3 point1, Vector3 point2, float radius, Vector3 direction) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] SphereCastAll(Vector3 origin, float radius, Vector3 direction, float maxDistance, int layerMask, QueryTriggerInteraction queryTriggerInteraction) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] SphereCastAll(Vector3 origin, float radius, Vector3 direction, float maxDistance, int layerMask) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] SphereCastAll(Vector3 origin, float radius, Vector3 direction, float maxDistance) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] SphereCastAll(Vector3 origin, float radius, Vector3 direction) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] SphereCastAll(Ray ray, float radius, float maxDistance, int layerMask, QueryTriggerInteraction queryTriggerInteraction) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] SphereCastAll(Ray ray, float radius, float maxDistance, int layerMask) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] SphereCastAll(Ray ray, float radius, float maxDistance) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] SphereCastAll(Ray ray, float radius) { return null; }
+		[PhysicsAllocMethodUsage] static Collider[] OverlapCapsule(Vector3 point0, Vector3 point1, float radius, int layerMask, QueryTriggerInteraction queryTriggerInteraction) { return null; }
+		[PhysicsAllocMethodUsage] static Collider[] OverlapCapsule(Vector3 point0, Vector3 point1, float radius, int layerMask) { return null; }
+		[PhysicsAllocMethodUsage] static Collider[] OverlapCapsule(Vector3 point0, Vector3 point1, float radius) { return null; }
+		[PhysicsAllocMethodUsage] static Collider[] OverlapSphere(Vector3 position, float radius, int layerMask, QueryTriggerInteraction queryTriggerInteraction) { return null; }
+		[PhysicsAllocMethodUsage] static Collider[] OverlapSphere(Vector3 position, float radius, int layerMask) { return null; }
+		[PhysicsAllocMethodUsage] static Collider[] OverlapSphere(Vector3 position, float radius) { return null; }
+		[PhysicsAllocMethodUsage] static Collider[] OverlapBox(Vector3 center, Vector3 halfExtents, Quaternion orientation) { return null; }
+		[PhysicsAllocMethodUsage] static Collider[] OverlapBox(Vector3 center, Vector3 halfExtents) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] BoxCastAll(Vector3 center, Vector3 halfExtents, Vector3 direction, Quaternion orientation, float maxDistance, int layerMask, QueryTriggerInteraction queryTriggerInteraction) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] BoxCastAll(Vector3 center, Vector3 halfExtents, Vector3 direction, Quaternion orientation, float maxDistance, int layerMask) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] BoxCastAll(Vector3 center, Vector3 halfExtents, Vector3 direction, Quaternion orientation, float maxDistance) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] BoxCastAll(Vector3 center, Vector3 halfExtents, Vector3 direction, Quaternion orientation) { return null; }
+		[PhysicsAllocMethodUsage] static RaycastHit[] BoxCastAll(Vector3 center, Vector3 halfExtents, Vector3 direction) { return null; }
+	}
 }
 
 namespace UnityEngine.EventSystems


### PR DESCRIPTION
#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Add an analyzer for flagging allocating APIs.  See https://docs.unity3d.com/Manual/BestPracticeUnderstandingPerformanceInUnity7.html

We only added support for `Physics` and not `Physics2D`. It seems that `Physics2D` non-alloc methods will be deprecated in a future build and it is recommended to use simpler API instead. See https://docs.unity3d.com/ScriptReference/Physics2D.BoxCastNonAlloc.html


