### PR TITLE
Add UNT0029, Pattern matching with null on Unity objects

### DIFF
--- a/doc/UNT0029.md
+++ b/doc/UNT0029.md
@@ -1,0 +1,39 @@
+# UNT0029 Pattern matching with null on Unity objects
+
+Unity overrides the null comparison operator for Unity objects, which is incompatible with pattern matching with null.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public Transform a = null;
+
+    public void Update()
+    {
+        if (a is not null) { }
+    }
+}
+```
+
+## Solution
+
+Use null comparison:
+
+```csharp
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public Transform a = null;
+
+    public void Update()
+    {
+        if (a != null) { }
+    }
+}
+```
+
+A code fix is offered for this diagnostic to automatically apply this change.

--- a/doc/index.md
+++ b/doc/index.md
@@ -30,6 +30,7 @@ ID | Title | Category
 [UNT0026](UNT0026.md) | GetComponent always allocates | Performance
 [UNT0027](UNT0027.md) | Do not call PropertyDrawer.OnGUI() | Correctness
 [UNT0028](UNT0028.md) | Use non-allocating physics APIs | Performance
+[UNT0029](UNT0029.md) | Pattern matching with null on Unity objects | Correctness
 
 # Diagnostic Suppressors
 

--- a/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingTests.cs
@@ -344,7 +344,6 @@ class Camera : MonoBehaviour
 		await VerifyCSharpFixAsync(test, fixedTest);
 	}
 
-
 	[Fact]
 	public async Task CoalescingAssignmentForRegularObjects()
 	{
@@ -359,6 +358,102 @@ class Camera : MonoBehaviour
     public System.Object NP()
     {
         return a ??= b;
+    }
+}
+";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task IsNullPatternExpression()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public Transform a = null;
+
+    public void Update()
+    {
+        if (a is null) { }
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic(UnityObjectNullHandlingAnalyzer.IsPatternRule)
+			.WithLocation(10, 13);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public Transform a = null;
+
+    public void Update()
+    {
+        if (a == null) { }
+    }
+}
+";
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task IsNotNullPatternExpression()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public Transform a = null;
+
+    public void Update()
+    {
+        if (a is not null) { }
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic(UnityObjectNullHandlingAnalyzer.IsPatternRule)
+			.WithLocation(10, 13);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public Transform a = null;
+
+    public void Update()
+    {
+        if (a != null) { }
+    }
+}
+";
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task IsRegularPatternExpression()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public object a = null;
+
+    public void Update()
+    {
+        if (a is not null) { }
     }
 }
 ";

--- a/src/Microsoft.Unity.Analyzers/Microsoft.Unity.Analyzers.csproj
+++ b/src/Microsoft.Unity.Analyzers/Microsoft.Unity.Analyzers.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -972,6 +972,42 @@ namespace Microsoft.Unity.Analyzers.Resources {
         /// <summary>
         ///   Looks up a localized string similar to Use null comparison.
         /// </summary>
+        internal static string UnityObjectIsPatternCodeFixTitle {
+            get {
+                return ResourceManager.GetString("UnityObjectIsPatternCodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unity overrides the null comparison operator for Unity objects, which is incompatible with pattern matching with null..
+        /// </summary>
+        internal static string UnityObjectIsPatternDiagnosticDescription {
+            get {
+                return ResourceManager.GetString("UnityObjectIsPatternDiagnosticDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unity objects should not use pattern matching with null..
+        /// </summary>
+        internal static string UnityObjectIsPatternDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("UnityObjectIsPatternDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pattern matching with null on Unity objects.
+        /// </summary>
+        internal static string UnityObjectIsPatternDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("UnityObjectIsPatternDiagnosticTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use null comparison.
+        /// </summary>
         internal static string UnityObjectNullCoalescingCodeFixTitle {
             get {
                 return ResourceManager.GetString("UnityObjectNullCoalescingCodeFixTitle", resourceCulture);

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -510,4 +510,16 @@
   <data name="PhysicsAllocMethodUsageDiagnosticTitle" xml:space="preserve">
     <value>Use non-allocating physics APIs</value>
   </data>
+  <data name="UnityObjectIsPatternCodeFixTitle" xml:space="preserve">
+    <value>Use null comparison</value>
+  </data>
+  <data name="UnityObjectIsPatternDiagnosticDescription" xml:space="preserve">
+    <value>Unity overrides the null comparison operator for Unity objects, which is incompatible with pattern expression with null.</value>
+  </data>
+  <data name="UnityObjectIsPatternDiagnosticMessageFormat" xml:space="preserve">
+    <value>Unity objects should not use pattern expression with null.</value>
+  </data>
+  <data name="UnityObjectIsPatternDiagnosticTitle" xml:space="preserve">
+    <value>Pattern expression with null on Unity objects</value>
+  </data>
 </root>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #228 

#### Checklist
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Add a diagnostic and codefix for pattern matching with `null` on Unity Objects

#### Changes proposed in this pull request:
- We need to bump Roslyn to `3.7.0` to support this scenario. This will limit our support to VS2019 16.7, and VSMac 8.7
- Given the following servicing [document](https://docs.microsoft.com/visualstudio/releases/2019/servicing-vs2019), I think it is safe to bump the Roslyn version.
