### PR TITLE
Add OnPostprocessAllAssets overload to prevent incorrect UNT0006

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/MessageSignatureTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/MessageSignatureTests.cs
@@ -232,4 +232,39 @@ class TestWindow : EditorWindow
 ";
 		await VerifyCSharpFixAsync(test, fixedTest);
 	}
+
+	[Fact]
+	public async Task MessageSignatureOverload()
+	{
+		const string test = @"
+using UnityEditor;
+
+class App : AssetPostprocessor
+{
+    static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
+    {
+    }
+}
+";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task MessageSignatureDidDomainReloadOverload()
+	{
+		const string test = @"
+using UnityEditor;
+
+class App : AssetPostprocessor
+{
+    static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
+    {
+    }
+}
+";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
 }

--- a/src/Microsoft.Unity.Analyzers/UnityStubs.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityStubs.cs
@@ -766,6 +766,7 @@ namespace UnityEditor
 		void OnPreprocessLightDescription(LightDescription description, Light light, AnimationClip[] clips) { }
 
 		static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths) { }
+		static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload) { }
 
 		// undocumented static methods
 		static bool OnPreGeneratingCSProjectFiles() { return false; }


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #237

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Add OnPostprocessAllAssets overload to prevent incorrect UNT0006