### PR TITLE
[Experiments] Add UNT00XX - Static member assignment while domain reload is disabled

### DIFF
--- a/doc/UNT0033.md
+++ b/doc/UNT0033.md
@@ -1,0 +1,32 @@
+# Static member assignment while domain reload is disabled
+
+When Domain Reloading is disabled, Unity does not reset the scripting state each time. It is then up to you to ensure your scripting state resets when you enter Play Mode:
+- You need to add code that explicitly reset the values of static fields.
+- Unity will not unregister methods from static event handlers when you exit Play Mode. This can lead to complications if you have code that registers methods with static event handlers.
+
+More information [here](https://docs.unity3d.com/Manual/DomainReloading.html).
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using UnityEngine;
+
+public class StaticCounterExample : MonoBehaviour
+{
+    // this counter will not reset to zero when Domain Reloading is disabled
+    static int counter = 0; 
+
+    // Update is called once per frame
+    void Update()
+    {
+            if (Input.GetButtonDown("Jump"))
+            {
+                    counter++;
+                    Debug.Log("Counter: " + counter);
+            }
+    }
+}```
+
+## Solution
+
+You can use `RuntimeInitializeOnLoadMethod` attribute for initializing state. Unity provides a guidance [here](https://docs.unity3d.com/Manual/DomainReloading.html).

--- a/doc/UNT0033.md
+++ b/doc/UNT0033.md
@@ -25,7 +25,8 @@ public class StaticCounterExample : MonoBehaviour
                     Debug.Log("Counter: " + counter);
             }
     }
-}```
+}
+```
 
 ## Solution
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -34,6 +34,7 @@ ID | Title | Category
 [UNT0030](UNT0030.md) | Calling Destroy or DestroyImmediate on a Transform | Correctness
 [UNT0031](UNT0031.md) | Asset operations in LoadAttribute method | Correctness
 [UNT0032](UNT0032.md) | Inefficient method to set localPosition and localRotation | Performance
+[UNT0033](UNT0033.md) | Static member assignment while domain reload is disabled | Correctness
 
 # Diagnostic Suppressors
 

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/AnalyzerVerificationContext.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/AnalyzerVerificationContext.cs
@@ -13,19 +13,22 @@ public readonly struct AnalyzerVerificationContext
 	public ImmutableDictionary<string, string> Options { get; }
 	public ImmutableArray<string> Filters { get; }
 	public LanguageVersion LanguageVersion { get; }
+	public ImmutableArray<string> PreprocessorSymbols { get; }
 
 	// CS1701 - Assuming assembly reference 'mscorlib, Version=2.0.0.0' used by 'UnityEngine' matches identity 'mscorlib, Version=4.0.0.0' of 'mscorlib', you may need to supply runtime policy
 	// CS0414 - cf. IDE0051
 	public static AnalyzerVerificationContext Default = new(
 		ImmutableDictionary<string, string>.Empty,
 		new[] {"CS1701", "CS0414"}.ToImmutableArray(),
-		LanguageVersion.Latest);
+		LanguageVersion.Latest,
+		ImmutableArray<string>.Empty);
 
-	public AnalyzerVerificationContext(ImmutableDictionary<string, string> options, ImmutableArray<string> filters, LanguageVersion languageVersion) : this()
+	public AnalyzerVerificationContext(ImmutableDictionary<string, string> options, ImmutableArray<string> filters, LanguageVersion languageVersion, ImmutableArray<string> preprocessorSymbols) : this()
 	{
 		Options = options;
 		Filters = filters;
 		LanguageVersion = languageVersion;
+		PreprocessorSymbols = preprocessorSymbols;
 	}
 
 	public AnalyzerVerificationContext WithAnalyzerOption(string key, string value)
@@ -33,7 +36,8 @@ public readonly struct AnalyzerVerificationContext
 		return new(
 			Options.Add(key, value),
 			Filters,
-			LanguageVersion);
+			LanguageVersion,
+			PreprocessorSymbols);
 	}
 
 	public AnalyzerVerificationContext WithAnalyzerFilter(string value)
@@ -41,7 +45,8 @@ public readonly struct AnalyzerVerificationContext
 		return new(
 			Options,
 			Filters.Add(value),
-			LanguageVersion);
+			LanguageVersion,
+			PreprocessorSymbols);
 	}
 
 	public AnalyzerVerificationContext WithLanguageVersion(LanguageVersion languageVersion)
@@ -49,6 +54,16 @@ public readonly struct AnalyzerVerificationContext
 		return new(
 			Options,
 			Filters,
-			languageVersion);
+			languageVersion,
+			PreprocessorSymbols);
+	}
+
+	public AnalyzerVerificationContext WithPreprocessorSymbol(string value)
+	{
+		return new(
+			Options,
+			Filters,
+			LanguageVersion,
+			PreprocessorSymbols.Add(value));
 	}
 }

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
@@ -347,6 +347,7 @@ public abstract class DiagnosticVerifier
 		var monolib = Path.Combine(installationFullPath, "MonoBleedingEdge", "lib", "mono", "4.7.1-api");
 		yield return Path.Combine(monolib, "mscorlib.dll");
 		yield return Path.Combine(monolib, "system.dll");
+		yield return Path.Combine(monolib, "System.Core.dll");
 
 		var facades = Path.Combine(monolib, "Facades");
 		yield return Path.Combine(facades, "netstandard.dll");

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
@@ -361,7 +361,13 @@ public abstract class DiagnosticVerifier
 			.AddProject(projectId, TestProjectName, TestProjectName, LanguageNames.CSharp);
 
 		solution = UnityAssemblies().Aggregate(solution, (current, dll) => current.AddMetadataReference(projectId, MetadataReference.CreateFromFile(dll)));
-		solution = solution.WithProjectParseOptions(projectId, new CSharpParseOptions(context.LanguageVersion));
+		
+		var parseOptions = CSharpParseOptions
+			.Default
+			.WithLanguageVersion(context.LanguageVersion)
+			.WithPreprocessorSymbols(context.PreprocessorSymbols);
+		
+		solution = solution.WithProjectParseOptions(projectId, parseOptions);
 
 		var count = 0;
 		foreach (var source in sources)

--- a/src/Microsoft.Unity.Analyzers.Tests/StaticMemberWithoutDomainReloadTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/StaticMemberWithoutDomainReloadTests.cs
@@ -1,0 +1,168 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests;
+
+public class StaticMemberWithoutDomainReloadTests : BaseDiagnosticVerifierTest<StaticMemberWithoutDomainReloadAnalyzer>
+{
+	private static AnalyzerVerificationContext Context => AnalyzerVerificationContext
+													.Default
+													.WithPreprocessorSymbol(StaticMemberWithoutDomainReloadAnalyzer.PreprocessorSymbolDisableDomainReload);
+
+
+	[Fact]
+	public async Task TestFieldAccess()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private static class StaticClass
+    {
+        public static int counter = 0;
+    }
+
+    private void Update()
+	{
+        StaticClass.counter = 66;
+	}
+}
+";
+
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(13, 9);
+
+		await VerifyCSharpDiagnosticAsync(test); // without proper define => no diagnostic
+		await VerifyCSharpDiagnosticAsync(Context, test, diagnostic);
+	}
+
+	
+	[Fact]
+	public async Task TestFieldAssignment()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private static int counter = 0;
+
+    private void Update()
+    {
+        counter = 66;
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(10,9);
+
+		await VerifyCSharpDiagnosticAsync(test); // without proper define => no diagnostic
+		await VerifyCSharpDiagnosticAsync(Context, test, diagnostic);
+	}
+	
+	[Fact]
+	public async Task TestFieldIncrement()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private static int counter = 0;
+
+    private void Update()
+    {
+        counter++;
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(10, 9);
+
+		await VerifyCSharpDiagnosticAsync(test); // without proper define => no diagnostic
+		await VerifyCSharpDiagnosticAsync(Context, test, diagnostic);
+	}
+
+	[Fact]
+	public async Task TestFieldDecrement()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private static int counter = 0;
+
+    private void Update()
+    {
+        --counter;
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(10, 11);
+
+		await VerifyCSharpDiagnosticAsync(test); // without proper define => no diagnostic
+		await VerifyCSharpDiagnosticAsync(Context, test, diagnostic);
+	}
+
+	[Fact]
+	public async Task TestEventHandler()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private void Start()
+    {
+        Application.quitting += delegate { };
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(8, 9);
+
+		await VerifyCSharpDiagnosticAsync(test); // without proper define => no diagnostic
+		await VerifyCSharpDiagnosticAsync(Context, test, diagnostic);
+	}
+
+	[Fact]
+	public async Task TestOwnEventHandler()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public static event System.Action ownEvent; 
+
+    private void Start()
+    {
+        ownEvent += delegate { };
+    }
+
+    private void Update()
+    {
+        ownEvent?.Invoke();
+    }
+}
+";
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(10, 9);
+
+		await VerifyCSharpDiagnosticAsync(test); // without proper define => no diagnostic
+		await VerifyCSharpDiagnosticAsync(Context, test, diagnostic);
+	}	
+	
+}

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -952,7 +952,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Static member &apos;{0}&apos; is assigned with domain reload disabled..
+        ///   Looks up a localized string similar to Static member is assigned with domain reload disabled..
         /// </summary>
         internal static string StaticMemberWithoutDomainReloadDiagnosticMessageFormat {
             get {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -943,6 +943,33 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Static member assignment when Unity Editor is setup to disable domain reload..
+        /// </summary>
+        internal static string StaticMemberWithoutDomainReloadDiagnosticDescription {
+            get {
+                return ResourceManager.GetString("StaticMemberWithoutDomainReloadDiagnosticDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Static member &apos;{0}&apos; is assigned with domain reload disabled..
+        /// </summary>
+        internal static string StaticMemberWithoutDomainReloadDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("StaticMemberWithoutDomainReloadDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Static member assignment while domain reload is disabled.
+        /// </summary>
+        internal static string StaticMemberWithoutDomainReloadDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("StaticMemberWithoutDomainReloadDiagnosticTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use CompareTag method.
         /// </summary>
         internal static string TagComparisonCodeFixTitle {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -555,4 +555,14 @@
   <data name="SetLocalPositionAndRotationDiagnosticTitle" xml:space="preserve">
     <value>Inefficient localPosition/localRotation assignment</value>
   </data>
+  <data name="StaticMemberWithoutDomainReloadDiagnosticDescription" xml:space="preserve">
+    <value>Static member assignment when Unity Editor is setup to disable domain reload.</value>
+  </data>
+  <data name="StaticMemberWithoutDomainReloadDiagnosticMessageFormat" xml:space="preserve">
+    <value>Static member '{0}' is assigned with domain reload disabled.</value>
+    <comment>{0} is a member name (field or event)</comment>
+  </data>
+  <data name="StaticMemberWithoutDomainReloadDiagnosticTitle" xml:space="preserve">
+    <value>Static member assignment while domain reload is disabled</value>
+  </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -559,8 +559,7 @@
     <value>Static member assignment when Unity Editor is setup to disable domain reload.</value>
   </data>
   <data name="StaticMemberWithoutDomainReloadDiagnosticMessageFormat" xml:space="preserve">
-    <value>Static member '{0}' is assigned with domain reload disabled.</value>
-    <comment>{0} is a member name (field or event)</comment>
+    <value>Static member is assigned with domain reload disabled.</value>
   </data>
   <data name="StaticMemberWithoutDomainReloadDiagnosticTitle" xml:space="preserve">
     <value>Static member assignment while domain reload is disabled</value>

--- a/src/Microsoft.Unity.Analyzers/StaticMemberWithoutDomainReload.cs
+++ b/src/Microsoft.Unity.Analyzers/StaticMemberWithoutDomainReload.cs
@@ -1,0 +1,70 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Unity.Analyzers.Resources;
+
+namespace Microsoft.Unity.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class StaticMemberWithoutDomainReloadAnalyzer : DiagnosticAnalyzer
+{
+	public const string PreprocessorSymbolDisableDomainReload = "VSTU_DISABLE_DOMAIN_RELOAD";
+
+	internal static readonly DiagnosticDescriptor Rule = new(
+		id: "UNT0033",
+		title: Strings.StaticMemberWithoutDomainReloadDiagnosticTitle,
+		messageFormat: Strings.StaticMemberWithoutDomainReloadDiagnosticMessageFormat,
+		category: DiagnosticCategory.Correctness,
+		defaultSeverity: DiagnosticSeverity.Info,
+		isEnabledByDefault: true,
+		description: Strings.StaticMemberWithoutDomainReloadDiagnosticDescription);
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+	public override void Initialize(AnalysisContext context)
+	{
+		context.EnableConcurrentExecution();
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+		context.RegisterSyntaxNodeAction(AnalyzeExpression, SyntaxKind.AddAssignmentExpression);
+		context.RegisterSyntaxNodeAction(AnalyzeExpression, SyntaxKind.SubtractAssignmentExpression);
+		context.RegisterSyntaxNodeAction(AnalyzeExpression, SyntaxKind.SimpleAssignmentExpression);
+		context.RegisterSyntaxNodeAction(AnalyzeExpression, SyntaxKind.PostIncrementExpression);
+		context.RegisterSyntaxNodeAction(AnalyzeExpression, SyntaxKind.PostDecrementExpression);
+		context.RegisterSyntaxNodeAction(AnalyzeExpression, SyntaxKind.PreIncrementExpression);
+		context.RegisterSyntaxNodeAction(AnalyzeExpression, SyntaxKind.PreDecrementExpression);
+	}
+	
+	private static void AnalyzeExpression(SyntaxNodeAnalysisContext context)
+	{
+		var node = context.Node;
+		if (!node.SyntaxTree.Options.PreprocessorSymbolNames.Contains(PreprocessorSymbolDisableDomainReload))
+			return;
+
+		var expression = node switch
+		{
+			PostfixUnaryExpressionSyntax postfixUnaryExpressionSyntax => postfixUnaryExpressionSyntax.Operand,
+			PrefixUnaryExpressionSyntax prefixUnaryExpressionSyntax => prefixUnaryExpressionSyntax.Operand,
+			AssignmentExpressionSyntax assignmentExpression => assignmentExpression.Left,
+			_ => null
+		};
+
+		if (expression == null)
+			return;
+
+		var model = context.SemanticModel;
+		var symbol = model.GetSymbolInfo(expression);
+
+		var candidate = symbol.Symbol;
+		if (candidate is IFieldSymbol or IEventSymbol && candidate.IsStatic)
+			context.ReportDiagnostic(Diagnostic.Create(Rule, expression.GetLocation(), candidate.Name));
+	}
+}


### PR DESCRIPTION
Fixes #225

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Add UNT0033 - Static member assignment while domain reload is disabled

Note: requires a new VS editor package version, able to set `VSTU_DISABLE_DOMAIN_RELOAD` preprocessor define. 