### PR TITLE
Detect unity installations on linux

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
@@ -357,7 +357,7 @@ public abstract class DiagnosticVerifier
 
 		var monolib = Path.Combine(installationFullPath, "MonoBleedingEdge", "lib", "mono", "4.7.1-api");
 		yield return Path.Combine(monolib, "mscorlib.dll");
-		yield return Path.Combine(monolib, "system.dll");
+		yield return Path.Combine(monolib, "System.dll");
 
 		var facades = Path.Combine(monolib, "Facades");
 		yield return Path.Combine(facades, "netstandard.dll");

--- a/src/Microsoft.Unity.Analyzers.Tests/UnityPath.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityPath.cs
@@ -28,10 +28,20 @@ internal static class UnityPath
 		{
 			RegisterRegistryInstallations();
 		}
-		else
+		else if (OperatingSystem.IsMacOS())
 		{
 			RegisterApplicationsInstallations();
 		}
+		else if (OperatingSystem.IsLinux())
+		{
+			RegisterLinuxInstallations();
+		}
+		else
+		{
+			throw new NotImplementedException("operating system not supported");
+		}
+
+		if (UnityInstallations.Count == 0) throw new Exception("could not locate a unity installation");
 	}
 
 	private static void RegisterApplicationsInstallations()
@@ -50,6 +60,26 @@ internal static class UnityPath
 		}
 
 		RegisterUnityInstallation("/Applications/Unity/Unity.app/Contents");
+	}
+
+	private static void RegisterLinuxInstallations()
+	{
+		string hub = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Unity/Hub/Editor");
+		if (Directory.Exists(hub))
+		{
+			var directories = Directory.EnumerateDirectories(hub)
+				.OrderByDescending(n => n)
+				.Select(n => Path.Combine(n, "Editor"));
+
+			foreach (var name in directories)
+			{
+				RegisterUnityInstallation(Path.Combine(name,"Data"));
+			}
+		}
+		else
+		{
+			throw new DirectoryNotFoundException($"could not locate unity hub at '{hub}'");
+		}
 	}
 
 	[SupportedOSPlatform("windows")]


### PR DESCRIPTION
Fixes #264 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:

Users should be able to run unit tests on linux. The test is that any test runs on linux at all so no new test is necessary.

#### Changes proposed in this pull request:
* Check for linux installations in $HOME/Unity/Hub
* Fix System.dll is actully capitalized and file systems on linux default to case sensitive
* Tested on Ubuntu 22.10
