### PR TITLE
Skippable facts

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -24,10 +24,11 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
 
-    <!-- Misc -->	
+    <!-- Misc -->
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />    
+    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
 
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -22,6 +22,7 @@
 
     <!-- Tests -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/src/Microsoft.Unity.Analyzers.Tests/BaseTest.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/BaseTest.cs
@@ -3,10 +3,14 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *-------------------------------------------------------------------------------------------*/
 
+using System;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
+using Xunit.Sdk;
 
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods",
 	Justification = "Tests",
@@ -39,7 +43,7 @@ class Failure : MonoBehaviour, IFailure {
 		await VerifyCSharpDiagnosticAsync(InterfaceTest);
 	}
 
-	protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+	protected override TAnalyzer GetCSharpDiagnosticAnalyzer()
 	{
 		return new TAnalyzer();
 	}
@@ -54,7 +58,7 @@ public abstract class BaseSuppressorVerifierTest<TAnalyzer> : SuppressorVerifier
 		await VerifyCSharpDiagnosticAsync(BaseDiagnosticVerifierTest<TAnalyzer>.InterfaceTest);
 	}
 
-	protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+	protected override TAnalyzer GetCSharpDiagnosticAnalyzer()
 	{
 		return new TAnalyzer();
 	}
@@ -70,13 +74,32 @@ public abstract class BaseCodeFixVerifierTest<TAnalyzer, TCodeFix> : CodeFixVeri
 		await VerifyCSharpDiagnosticAsync(BaseDiagnosticVerifierTest<TAnalyzer>.InterfaceTest);
 	}
 
-	protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+	protected override TAnalyzer GetCSharpDiagnosticAnalyzer()
 	{
 		return new TAnalyzer();
 	}
 
-	protected override CodeFixProvider GetCSharpCodeFixProvider()
+	protected override TCodeFix GetCSharpCodeFixProvider()
 	{
 		return new TCodeFix();
+	}
+
+	protected bool MethodExists(string typeName, string methodName, string assenblyNameFilter = "")
+	{
+		foreach (var assemblyFile in UnityAssemblies().Where(n => n.Contains(assenblyNameFilter)))
+		{
+			var assembly = Assembly.LoadFile(assemblyFile);
+			var type = assembly.GetType(typeName, false);
+			if (type == null)
+				continue;
+
+			var method = type.GetMethod(methodName);
+			if (method == null)
+				continue;
+
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/DiagnosticVerifier.cs
@@ -324,7 +324,7 @@ public abstract class DiagnosticVerifier
 		return CreateProject(context, new[] {source}).Documents.First();
 	}
 
-	private static IEnumerable<string> UnityAssemblies()
+	protected static IEnumerable<string> UnityAssemblies()
 	{
 		var firstInstallationPath = UnityPath.FirstInstallation();
 		string installationFullPath = firstInstallationPath;

--- a/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
+++ b/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="4.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" />
     <PackageReference Include="xunit" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />    
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />

--- a/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
+++ b/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
@@ -15,7 +15,8 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />    
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" />	
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="Xunit.SkippableFact" />	
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Unity.Analyzers.Tests/SetLocalPositionAndRotationTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/SetLocalPositionAndRotationTests.cs
@@ -30,7 +30,7 @@ class Camera : MonoBehaviour
 		var method = GetCSharpDiagnosticAnalyzer().ExpressionContext.SetPositionAndRotationMethodName;
 		var type = typeof(UnityEngine.Transform);
 
-		Skip.IfNot(MethodExists(type.FullName!, method, type.Namespace!), $"This Unity version does not support {type}.{method}");
+		Skip.IfNot(MethodExists("UnityEngine", type.FullName!, method), $"This Unity version does not support {type}.{method}");
 
 		var diagnostic = ExpectDiagnostic().WithLocation(8, 9);
 

--- a/src/Microsoft.Unity.Analyzers.Tests/SetLocalPositionAndRotationTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/SetLocalPositionAndRotationTests.cs
@@ -30,7 +30,7 @@ class Camera : MonoBehaviour
 		var method = GetCSharpDiagnosticAnalyzer().ExpressionContext.SetPositionAndRotationMethodName;
 		var type = typeof(UnityEngine.Transform);
 
-		Skip.IfNot(MethodExists(type.FullName!, method, type.Namespace!), "This Unity version does not support {type}.{method}");
+		Skip.IfNot(MethodExists(type.FullName!, method, type.Namespace!), $"This Unity version does not support {type}.{method}");
 
 		var diagnostic = ExpectDiagnostic().WithLocation(8, 9);
 

--- a/src/Microsoft.Unity.Analyzers.Tests/SetLocalPositionAndRotationTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/SetLocalPositionAndRotationTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Unity.Analyzers.Tests;
 public class SetLocalPositionAndRotationTests : BaseCodeFixVerifierTest<SetLocalPositionAndRotationAnalyzer, SetLocalPositionAndRotationCodeFix>
 {
 	// For extensive testing, see SetPositionAndRotationTests.cs
-	[Fact]
+	[SkippableFact]
 	public async Task UpdateLocalPositionAndRotationMethod()
 	{
 		const string test = @"
@@ -26,6 +26,11 @@ class Camera : MonoBehaviour
     }
 }
 ";
+
+		var method = GetCSharpDiagnosticAnalyzer().ExpressionContext.SetPositionAndRotationMethodName;
+		var type = typeof(UnityEngine.Transform);
+
+		Skip.IfNot(MethodExists(type.FullName!, method, type.Namespace!), "This Unity version does not support {type}.{method}");
 
 		var diagnostic = ExpectDiagnostic().WithLocation(8, 9);
 

--- a/src/Microsoft.Unity.Analyzers/BaseSetPositionAndRotation.cs
+++ b/src/Microsoft.Unity.Analyzers/BaseSetPositionAndRotation.cs
@@ -106,7 +106,7 @@ public class BaseSetPositionAndRotationContext
 
 public abstract class BaseSetPositionAndRotationAnalyzer : DiagnosticAnalyzer
 {
-	private BaseSetPositionAndRotationContext ExpressionContext { get; }
+	internal BaseSetPositionAndRotationContext ExpressionContext { get; }
 
 	protected BaseSetPositionAndRotationAnalyzer(BaseSetPositionAndRotationContext expressionContext)
 	{


### PR DESCRIPTION
Fixes #263 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Add skippable facts support to conditionally ignore tests.

Example with 2021.3.9f1 (`Transform.SetLocalPositionAndRotation` was added in 2021.3.11f1)

This is only useful when full analyzer compilation is not needed. For other advanced usages we have `AnalyzerVerificationContext` to filter given options, ids or LanguageVersion (that we use for suppressor tests). 

![image](https://user-images.githubusercontent.com/638167/214356760-d8647e7d-c66a-4e9e-a3fb-aeca45f1aed2.png)

