### PR TITLE
Ignore CS0618 for `CantFixNullPropagationSideEffect`

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingTests.cs
@@ -250,10 +250,14 @@ class Camera : MonoBehaviour
 }
 ";
 
+		var context = AnalyzerVerificationContext
+			.Default                       // see https://github.com/Unity-Technologies/UnityCsReference/blob/master/Runtime/Export/Scripting/UnityEngineObject.bindings.cs
+			.WithAnalyzerFilter("CS0618"); // ignore Unity 2023.x warning CS0618 for now: 'Object.FindObjectOfType<T>()' is obsolete'
+
 		var diagnostic = ExpectDiagnostic(UnityObjectNullHandlingAnalyzer.NullPropagationRule)
 			.WithLocation(8, 9);
 
-		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+		await VerifyCSharpDiagnosticAsync(context, test, diagnostic);
 
 		// we cannot fix with side-effects
 		await VerifyCSharpFixAsync(test, test);


### PR DESCRIPTION
#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;

#### Short description of what this resolves:
Ignore CS0618 for `CantFixNullPropagationSideEffect`. Obsolete attribute was introduced with Unity 2023.1.