### PR TITLE
Add support for TransformAccess in UNT0032 and UNT0022

### DIFF
--- a/doc/UNT0022.md
+++ b/doc/UNT0022.md
@@ -1,6 +1,6 @@
 # UNT0022 Inefficient method to set position and rotation 
 
-Accessing the `Transform` should be done as few times as possible for performance reasons. Instead of setting `position` and `rotation` sequentially, you should use `SetPositionAndRotation()` method.
+Accessing the `Transform/TransformAccess` should be done as few times as possible for performance reasons. Instead of setting `position` and `rotation` sequentially, you should use `SetPositionAndRotation()` method.
 
 ## Examples of patterns that are flagged by this analyzer
 

--- a/doc/UNT0032.md
+++ b/doc/UNT0032.md
@@ -1,6 +1,6 @@
 # UNT0032 Inefficient method to set localPosition and localRotation 
 
-Accessing the `Transform` should be done as few times as possible for performance reasons. Starting with Unity 2021.3.11f1, instead of setting `localPosition` and `localRotation` sequentially, you should use `SetLocalPositionAndRotation()` method.
+Accessing the `Transform/TransformAccess` should be done as few times as possible for performance reasons. Starting with Unity 2021.3.11f1, instead of setting `localPosition` and `localRotation` sequentially, you should use `SetLocalPositionAndRotation()` method.
 
 ## Examples of patterns that are flagged by this analyzer
 

--- a/src/Microsoft.Unity.Analyzers.Tests/SetLocalPositionAndRotationTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/SetLocalPositionAndRotationTests.cs
@@ -27,7 +27,7 @@ class Camera : MonoBehaviour
 }
 ";
 
-		var method = GetCSharpDiagnosticAnalyzer().ExpressionContext.SetPositionAndRotationMethodName;
+		var method = GetCSharpDiagnosticAnalyzer().ExpressionContext.PositionAndRotationMethodName;
 		var type = typeof(UnityEngine.Transform);
 
 		Skip.IfNot(MethodExists("UnityEngine", type.FullName!, method), $"This Unity version does not support {type}.{method}");
@@ -50,4 +50,49 @@ class Camera : MonoBehaviour
 
 		await VerifyCSharpFixAsync(test, fixedTest);
 	}
+
+	[SkippableFact]
+	public async Task UpdateLocalPositionAndRotationMethodTransformAccess()
+	{
+		const string test = @"
+using UnityEngine;
+using UnityEngine.Jobs;
+
+class Context
+{
+    void Method()
+    {
+        var stub = new TransformAccess();
+        stub.localPosition = new Vector3(0.0f, 1.0f, 0.0f);
+        stub.localRotation = stub.localRotation;
+    }
+}
+";
+
+		var method = GetCSharpDiagnosticAnalyzer().ExpressionContext.PositionAndRotationMethodName;
+		var type = typeof(UnityEngine.Jobs.TransformAccess);
+
+		Skip.IfNot(MethodExists("UnityEngine", type.FullName!, method), $"This Unity version does not support {type}.{method}");
+
+		var diagnostic = ExpectDiagnostic().WithLocation(10, 9);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+using UnityEngine.Jobs;
+
+class Context
+{
+    void Method()
+    {
+        var stub = new TransformAccess();
+        stub.SetLocalPositionAndRotation(new Vector3(0.0f, 1.0f, 0.0f), stub.localRotation);
+    }
+}
+";
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
 }

--- a/src/Microsoft.Unity.Analyzers/BasePositionAndRotation.cs
+++ b/src/Microsoft.Unity.Analyzers/BasePositionAndRotation.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/src/Microsoft.Unity.Analyzers/BasePositionAndRotation.cs
+++ b/src/Microsoft.Unity.Analyzers/BasePositionAndRotation.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -21,44 +22,55 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Unity.Analyzers;
 
-public class BaseSetPositionAndRotationContext
+public class BasePositionAndRotationContext
 {
 	public string PositionPropertyName { get; }
 	public string RotationPropertyName { get; }
-	public string SetPositionAndRotationMethodName { get; }
+	public string PositionAndRotationMethodName { get; }
 
-	protected BaseSetPositionAndRotationContext(string positionPropertyName, string rotationPropertyName, string setPositionAndRotationMethodName)
+	protected BasePositionAndRotationContext(string positionPropertyName, string rotationPropertyName, string positionAndRotationMethodName)
 	{
 		PositionPropertyName = positionPropertyName;
 		RotationPropertyName = rotationPropertyName;
-		SetPositionAndRotationMethodName = setPositionAndRotationMethodName;
+		PositionAndRotationMethodName = positionAndRotationMethodName;
 	}
 
-	private bool IsSetPositionOrRotation(SemanticModel model, AssignmentExpressionSyntax assignmentExpression)
+	public MemberAccessExpressionSyntax? TryGetPropertyExpression(AssignmentExpressionSyntax assignmentExpression)
 	{
-		var property = GetProperty(assignmentExpression);
+		return assignmentExpression.Left as MemberAccessExpressionSyntax;
+	}
+
+	public ArgumentSyntax GetArgumentExpression(AssignmentExpressionSyntax assignmentExpression)
+	{
+		return Argument(assignmentExpression.Right);
+	}
+
+	private bool IsPositionOrRotationCandidate(SemanticModel model, AssignmentExpressionSyntax assignmentExpression)
+	{
+		var property = GetPropertyName(assignmentExpression);
 		if (property != PositionPropertyName && property != RotationPropertyName)
 			return false;
 
-		if (assignmentExpression.Left is not MemberAccessExpressionSyntax left)
+		if (TryGetPropertyExpression(assignmentExpression) is not { } syntax)
 			return false;
 
-		var leftSymbol = model.GetSymbolInfo(left);
-		if (leftSymbol.Symbol is not IPropertySymbol)
+		var symbolInfo = model.GetSymbolInfo(syntax);
+		if (symbolInfo.Symbol is not IPropertySymbol)
 			return false;
 		
-		var leftExpressionTypeInfo = model.GetTypeInfo(left.Expression);
-		if (leftExpressionTypeInfo.Type == null)
+		var expressionTypeInfo = model.GetTypeInfo(syntax.Expression);
+		if (expressionTypeInfo.Type == null)
 			return false;
 
-		return leftExpressionTypeInfo.Type.Extends(typeof(UnityEngine.Transform));
+		return expressionTypeInfo.Type.Extends(typeof(UnityEngine.Transform))
+			|| expressionTypeInfo.Type.Extends(typeof(UnityEngine.Jobs.TransformAccess));
 	}
 
 	public bool GetNextAssignmentExpression(SemanticModel model, AssignmentExpressionSyntax assignmentExpression, [NotNullWhen(true)] out AssignmentExpressionSyntax? assignmentExpressionSyntax)
 	{
 		assignmentExpressionSyntax = null;
 
-		if (!IsSetPositionOrRotation(model, assignmentExpression))
+		if (!IsPositionOrRotationCandidate(model, assignmentExpression))
 			return false;
 
 		if (assignmentExpression.FirstAncestorOrSelf<BlockSyntax>() == null)
@@ -88,27 +100,27 @@ public class BaseSetPositionAndRotationContext
 		if (statement is not ExpressionStatementSyntax {Expression: AssignmentExpressionSyntax nextAssignmentExpression})
 			return false;
 
-		if (!IsSetPositionOrRotation(model, nextAssignmentExpression))
+		if (!IsPositionOrRotationCandidate(model, nextAssignmentExpression))
 			return false;
 
 		assignmentExpressionSyntax = nextAssignmentExpression;
 		return true;
 	}
 
-	public static string GetProperty(AssignmentExpressionSyntax assignmentExpression)
+	public string GetPropertyName(AssignmentExpressionSyntax assignmentExpression)
 	{
-		if (assignmentExpression.Left is not MemberAccessExpressionSyntax left)
+		if (TryGetPropertyExpression(assignmentExpression) is not { } syntax)
 			return string.Empty;
 
-		return left.Name.ToString();
+		return syntax.Name.ToString();
 	}
 }
 
-public abstract class BaseSetPositionAndRotationAnalyzer : DiagnosticAnalyzer
+public abstract class BasePositionAndRotationAnalyzer : DiagnosticAnalyzer
 {
-	internal BaseSetPositionAndRotationContext ExpressionContext { get; }
+	internal BasePositionAndRotationContext ExpressionContext { get; }
 
-	protected BaseSetPositionAndRotationAnalyzer(BaseSetPositionAndRotationContext expressionContext)
+	protected BasePositionAndRotationAnalyzer(BasePositionAndRotationContext expressionContext)
 	{
 		ExpressionContext = expressionContext;
 	}
@@ -118,6 +130,7 @@ public abstract class BaseSetPositionAndRotationAnalyzer : DiagnosticAnalyzer
 		context.EnableConcurrentExecution();
 		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 		context.RegisterSyntaxNodeAction(AnalyzeAssignment, SyntaxKind.SimpleAssignmentExpression);
+		context.RegisterSyntaxNodeAction(AnalyzeAssignment, SyntaxKind.VariableDeclaration);
 	}
 
 	private void AnalyzeAssignment(SyntaxNodeAnalysisContext context)
@@ -128,23 +141,24 @@ public abstract class BaseSetPositionAndRotationAnalyzer : DiagnosticAnalyzer
 		if (!ExpressionContext.GetNextAssignmentExpression(context.SemanticModel, assignmentExpression, out var nextAssignmentExpression))
 			return;
 
-		// We know that both assignmentExpression.Left and nextAssignmentExpression.Left are MemberAccessExpressionSyntax
-		// cf. GetNextAssignmentExpression calling IsSetPositionOrRotation
-		var left = (MemberAccessExpressionSyntax)assignmentExpression.Left;
-		var nextLeft = (MemberAccessExpressionSyntax)nextAssignmentExpression.Left;
-		
-		if (left.Expression.ToString() != nextLeft.Expression.ToString())
+		if (ExpressionContext.TryGetPropertyExpression(assignmentExpression) is not { } syntax)
 			return;
 
-		var property = BaseSetPositionAndRotationContext.GetProperty(assignmentExpression);
-		var nextProperty = BaseSetPositionAndRotationContext.GetProperty(nextAssignmentExpression);
+		if (ExpressionContext.TryGetPropertyExpression(nextAssignmentExpression) is not { } nextSyntax)
+			return;
+		
+		if (syntax.Expression.ToString() != nextSyntax.Expression.ToString())
+			return;
+
+		var property = ExpressionContext.GetPropertyName(assignmentExpression);
+		var nextProperty = ExpressionContext.GetPropertyName(nextAssignmentExpression);
 		if (property == nextProperty)
 			return;
 
-		// Check that the replacement method exists on Transform in the current Unity version
+		// Check that the replacement method exists on target type in the current Unity version
 		var model = context.SemanticModel;
-		var type = model.GetTypeInfo(left.Expression).Type;
-		if (type == null || !type.GetMembers().Any(m => m is IMethodSymbol && m.Name == ExpressionContext.SetPositionAndRotationMethodName))
+		var type = model.GetTypeInfo(syntax.Expression).Type;
+		if (type == null || !type.GetMembers().Any(m => m is IMethodSymbol && m.Name == ExpressionContext.PositionAndRotationMethodName))
 			return;
 
 		OnPatternFound(context, assignmentExpression);
@@ -153,13 +167,13 @@ public abstract class BaseSetPositionAndRotationAnalyzer : DiagnosticAnalyzer
 	protected abstract void OnPatternFound(SyntaxNodeAnalysisContext context, AssignmentExpressionSyntax assignmentExpressionSyntax);
 }
 
-public abstract class BaseSetPositionAndRotationCodeFix : CodeFixProvider
+public abstract class BasePositionAndRotationCodeFix : CodeFixProvider
 {
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
-	private BaseSetPositionAndRotationContext ExpressionContext { get; }
+	private BasePositionAndRotationContext ExpressionContext { get; }
 
-	protected BaseSetPositionAndRotationCodeFix(BaseSetPositionAndRotationContext expressionContext)
+	protected BasePositionAndRotationCodeFix(BasePositionAndRotationContext expressionContext)
 	{
 		ExpressionContext = expressionContext;
 	}
@@ -189,12 +203,14 @@ public abstract class BaseSetPositionAndRotationCodeFix : CodeFixProvider
 		if (!ExpressionContext.GetNextAssignmentExpression(model, assignmentExpression, out var nextAssignmentExpression))
 			return document;
 
-		var property = BaseSetPositionAndRotationContext.GetProperty(assignmentExpression);
+		var property = ExpressionContext.GetPropertyName(assignmentExpression);
 		var arguments = new[]
 		{
-			Argument(assignmentExpression.Right)
+			ExpressionContext
+				.GetArgumentExpression(assignmentExpression)
 				.WithLeadingTrivia(assignmentExpression.OperatorToken.TrailingTrivia),
-			Argument(nextAssignmentExpression.Right)
+			ExpressionContext
+				.GetArgumentExpression(nextAssignmentExpression)
 				.WithLeadingTrivia(nextAssignmentExpression.OperatorToken.TrailingTrivia)
 		};
 
@@ -204,8 +220,7 @@ public abstract class BaseSetPositionAndRotationCodeFix : CodeFixProvider
 		var argList = ArgumentList()
 			.AddArguments(arguments);
 
-		var baseExpression = assignmentExpression
-			.Left
+		var baseExpression = ExpressionContext.TryGetPropertyExpression(assignmentExpression)?
 			.FirstAncestorOrSelf<MemberAccessExpressionSyntax>()?.Expression;
 
 		if (baseExpression == null)
@@ -215,7 +230,7 @@ public abstract class BaseSetPositionAndRotationCodeFix : CodeFixProvider
 				MemberAccessExpression(
 					SyntaxKind.SimpleMemberAccessExpression,
 					baseExpression,
-					IdentifierName(ExpressionContext.SetPositionAndRotationMethodName)))
+					IdentifierName(ExpressionContext.PositionAndRotationMethodName)))
 			.WithArgumentList(argList)
 			.WithLeadingTrivia(assignmentExpression.MergeLeadingTriviaWith(nextAssignmentExpression));
 

--- a/src/Microsoft.Unity.Analyzers/SetLocalPositionAndRotation.cs
+++ b/src/Microsoft.Unity.Analyzers/SetLocalPositionAndRotation.cs
@@ -13,14 +13,14 @@ using Microsoft.Unity.Analyzers.Resources;
 
 namespace Microsoft.Unity.Analyzers;
 
-public class SetLocalPositionAndRotationContext : BaseSetPositionAndRotationContext
+public class SetLocalPositionAndRotationContext : BasePositionAndRotationContext
 {
-	public static Lazy<BaseSetPositionAndRotationContext> Instance => new(() => new SetLocalPositionAndRotationContext());
+	public static Lazy<BasePositionAndRotationContext> Instance => new(() => new SetLocalPositionAndRotationContext());
 	private SetLocalPositionAndRotationContext() : base("localPosition", "localRotation", "SetLocalPositionAndRotation") { }
 }
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class SetLocalPositionAndRotationAnalyzer : BaseSetPositionAndRotationAnalyzer
+public class SetLocalPositionAndRotationAnalyzer : BasePositionAndRotationAnalyzer
 {
 	private const string RuleId = "UNT0032";
 
@@ -45,7 +45,7 @@ public class SetLocalPositionAndRotationAnalyzer : BaseSetPositionAndRotationAna
 }
 
 [ExportCodeFixProvider(LanguageNames.CSharp)]
-public class SetLocalPositionAndRotationCodeFix : BaseSetPositionAndRotationCodeFix
+public class SetLocalPositionAndRotationCodeFix : BasePositionAndRotationCodeFix
 {
 	protected override string CodeFixTitle => Strings.SetLocalPositionAndRotationCodeFixTitle;
 	

--- a/src/Microsoft.Unity.Analyzers/SetPositionAndRotation.cs
+++ b/src/Microsoft.Unity.Analyzers/SetPositionAndRotation.cs
@@ -13,14 +13,14 @@ using Microsoft.Unity.Analyzers.Resources;
 
 namespace Microsoft.Unity.Analyzers;
 
-public class SetPositionAndRotationContext : BaseSetPositionAndRotationContext
+public class SetPositionAndRotationContext : BasePositionAndRotationContext
 {
-	public static Lazy<BaseSetPositionAndRotationContext> Instance => new(() => new SetPositionAndRotationContext());
+	public static Lazy<BasePositionAndRotationContext> Instance => new(() => new SetPositionAndRotationContext());
 	private SetPositionAndRotationContext() : base("position", "rotation", "SetPositionAndRotation") { }
 }
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class SetPositionAndRotationAnalyzer : BaseSetPositionAndRotationAnalyzer
+public class SetPositionAndRotationAnalyzer : BasePositionAndRotationAnalyzer
 {
 	private const string RuleId = "UNT0022";
 
@@ -45,7 +45,7 @@ public class SetPositionAndRotationAnalyzer : BaseSetPositionAndRotationAnalyzer
 }
 
 [ExportCodeFixProvider(LanguageNames.CSharp)]
-public class SetPositionAndRotationCodeFix : BaseSetPositionAndRotationCodeFix
+public class SetPositionAndRotationCodeFix : BasePositionAndRotationCodeFix
 {
 	protected override string CodeFixTitle => Strings.SetPositionAndRotationCodeFixTitle;
 

--- a/src/Microsoft.Unity.Analyzers/UnityStubs.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityStubs.cs
@@ -84,10 +84,8 @@ namespace UnityEngine
 
 	class Transform
 	{
-		void position() { }
-		void rotation() { }
-		void SetPositionAndRotation() { }
 	}
+
 	class ScriptableObject
 	{
 		void Awake() { }
@@ -778,6 +776,13 @@ namespace UnityEditor
 		static string OnGeneratedCSProject(string path, string content) { return null; }
 	}
 
+}
+
+namespace UnityEngine.Jobs
+{
+	struct TransformAccess
+	{
+	}
 }
 
 namespace JetBrains.Annotations


### PR DESCRIPTION
#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Add support for `TransformAccess`  #257.
Add initial refactoring needed to support `Get*` functions.

It will be a bit more complicated for `Get*` because we'll have to support `VariableDeclarationSyntax` in addition of `AssignmentExpressionSyntax`. Like for:

```csharp
var foo = transform.position;
existing = transform.location;
=>
transform.GetPositionAndRotation(out var foo, out existing);
```

And we have to check that the argument passed as an `out/ref` is compatible. (like it is not a property).   

