### PR TITLE
Fix USP0008 with partial types

### DIFF
--- a/src/Microsoft.Unity.Analyzers/UnusedMethodSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/UnusedMethodSuppressor.cs
@@ -36,8 +36,6 @@ public class UnusedMethodSuppressor : DiagnosticSuppressor
 		if (syntaxTree == null)
 			return;
 
-		var root = syntaxTree.GetRoot(context.CancellationToken);
-
 		var methodDeclarationSyntax = context.GetSuppressibleNode<MethodDeclarationSyntax>(diagnostic);
 		if (methodDeclarationSyntax == null)
 			return;
@@ -54,8 +52,8 @@ public class UnusedMethodSuppressor : DiagnosticSuppressor
 			typeSymbol = typeSymbol.ContainingType;
 
 		var report = typeSymbol.Locations
-			.Select(location => root.FindNode(location.SourceSpan))
-			.SelectMany(typeNode => typeNode.DescendantNodes())
+			.Select(location => location.SourceTree?.GetRoot(context.CancellationToken).FindNode(location.SourceSpan))
+			.SelectMany(typeNode => typeNode?.DescendantNodes())
 			.OfType<InvocationExpressionSyntax>()
 			.Any(e => MethodInvocationAnalyzer.InvocationMatches(e, out string? argument) && argument == methodSymbol.Name);
 


### PR DESCRIPTION
Fix an `ArgumentOutOfRangeException` when using partial types with `UNT0008`.

We were using the diagnostic' `SourceTree` instead of the specific method location' `SourceTree` (which is the same of course for non-partial types).

I also audited all other `FindNode` usages, we should be good. 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;
