### PR TITLE
Do not expose categories through resources

### DIFF
--- a/src/Microsoft.Unity.Analyzers/DiagnosticCategory.cs
+++ b/src/Microsoft.Unity.Analyzers/DiagnosticCategory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Unity.Analyzers;
 
 public static class DiagnosticCategory
 {
-	public static readonly string Performance = Strings.CategoryPerformance;
-	public static readonly string Correctness = Strings.CategoryCorrectness;
-	public static readonly string TypeSafety = Strings.CategoryTypeSafety;
+	public static readonly string Performance = nameof(Performance);
+	public static readonly string Correctness = nameof(Correctness);
+	public static readonly string TypeSafety = nameof(TypeSafety);
 }

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -88,33 +88,6 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Correctness.
-        /// </summary>
-        internal static string CategoryCorrectness {
-            get {
-                return ResourceManager.GetString("CategoryCorrectness", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Performance.
-        /// </summary>
-        internal static string CategoryPerformance {
-            get {
-                return ResourceManager.GetString("CategoryPerformance", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Type Safety.
-        /// </summary>
-        internal static string CategoryTypeSafety {
-            get {
-                return ResourceManager.GetString("CategoryTypeSafety", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Component &apos;{0}&apos; should not be instantiated directly..
         /// </summary>
         internal static string CreateComponentInstanceDiagnosticMessageFormat {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -117,15 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CategoryCorrectness" xml:space="preserve">
-    <value>Correctness</value>
-  </data>
-  <data name="CategoryPerformance" xml:space="preserve">
-    <value>Performance</value>
-  </data>
-  <data name="CategoryTypeSafety" xml:space="preserve">
-    <value>Type Safety</value>
-  </data>
   <data name="EmptyUnityMessageCodeFixTitle" xml:space="preserve">
     <value>Remove empty Unity message</value>
   </data>


### PR DESCRIPTION
Fixes #297 

#### Checklist
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;

#### Short description of what this resolves:
Given diagnostic categories are used for bulk enabling/disabling analyzers like in `.editorconfig` files, keep technical names without exposing them through resources.