### PR TITLE
Fix trivia handling with UNT0021, when using messages without modifiers

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/ProtectedUnityMessageTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ProtectedUnityMessageTests.cs
@@ -51,6 +51,48 @@ class Camera : MonoBehaviour
 	}
 
 	[Fact]
+	public async Task FixDefaultUnityMessageComments()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    // comment with a space
+    void Start() /* comment with space */
+    {
+    }
+
+    void Foo()
+    {
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic().WithLocation(7, 10);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    // comment with a space
+    protected void Start() /* comment with space */
+    {
+    }
+
+    void Foo()
+    {
+    }
+}
+";
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
 	public async Task FixPrivateUnityMessageComments()
 	{
 		const string test = @"

--- a/src/Microsoft.Unity.Analyzers/ProtectedUnityMessage.cs
+++ b/src/Microsoft.Unity.Analyzers/ProtectedUnityMessage.cs
@@ -100,9 +100,13 @@ public class ProtectedUnityMessageCodeFix : CodeFixProvider
 	private static async Task<Document> MakeMessageProtectedAsync(Document document, MethodDeclarationSyntax declaration, CancellationToken cancellationToken)
 	{
 		var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+		// Use two steps to preserve trivia, because WithModifiers will not behave the same if we already have modifiers or not
+		var trivia = declaration.GetLeadingTrivia();
 		var newDeclaration = declaration
+			.WithLeadingTrivia()
 			.WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword)))
-			.WithLeadingTrivia(declaration.GetLeadingTrivia());
+			.WithLeadingTrivia(trivia);
 
 		foreach (var modifier in declaration.Modifiers)
 		{


### PR DESCRIPTION
Found while investigating #308 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Fix trivia handling with UNT0021, when using messages without modifiers
