### PR TITLE
Fix BatchFixer

### DIFF
--- a/src/Microsoft.Unity.Analyzers/BasePositionAndRotation.cs
+++ b/src/Microsoft.Unity.Analyzers/BasePositionAndRotation.cs
@@ -180,7 +180,7 @@ public abstract class BasePositionAndRotationCodeFix(BasePositionAndRotationCont
 			CodeAction.Create(
 				CodeFixTitle,
 				ct => ReplaceWithInvocationAsync(context.Document, statement, ct),
-				statement.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/BaseVectorConversion.cs
+++ b/src/Microsoft.Unity.Analyzers/BaseVectorConversion.cs
@@ -128,7 +128,7 @@ public abstract class BaseVectorConversionCodeFix : CodeFixProvider
 			CodeAction.Create(
 				title,
 				ct => SimplifyObjectCreationAsync(context.Document, ocSyntax, ct),
-				ocSyntax.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/CreateInstance.cs
+++ b/src/Microsoft.Unity.Analyzers/CreateInstance.cs
@@ -105,7 +105,7 @@ public class CreateInstanceCodeFix : CodeFixProvider
 					CodeAction.Create(
 						Strings.CreateScriptableObjectInstanceCodeFixTitle,
 						ct => ReplaceWithInvocationAsync(context.Document, creation, "ScriptableObject", "CreateInstance", ct),
-						creation.ToFullString()),
+						diagnostic.Id), // using DiagnosticId as equivalence key for BatchFixer
 					context.Diagnostics);
 				break;
 			case CreateInstanceAnalyzer.ComponentId when !IsInsideComponent(creation, model):
@@ -115,7 +115,7 @@ public class CreateInstanceCodeFix : CodeFixProvider
 					CodeAction.Create(
 						Strings.CreateMonoBehaviourInstanceCodeFixTitle,
 						ct => ReplaceWithInvocationAsync(context.Document, creation, "gameObject", "AddComponent", ct),
-						creation.ToFullString()),
+						diagnostic.Id), // using DiagnosticId as equivalence key for BatchFixer
 					context.Diagnostics);
 				break;
 		}

--- a/src/Microsoft.Unity.Analyzers/DestroyTransform.cs
+++ b/src/Microsoft.Unity.Analyzers/DestroyTransform.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -123,7 +124,7 @@ public class DestroyTransformCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.DestroyTransformCodeFixTitle,
 				ct => UseGameObjectAsync(context.Document, argument, ct),
-				invocation.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/EmptyUnityMessage.cs
+++ b/src/Microsoft.Unity.Analyzers/EmptyUnityMessage.cs
@@ -4,6 +4,7 @@
  *-------------------------------------------------------------------------------------------*/
 
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -92,7 +93,7 @@ public class EmptyUnityMessageCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.EmptyUnityMessageCodeFixTitle,
 				ct => DeleteEmptyMessageAsync(context.Document, declaration, ct),
-				declaration.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/ImproperMenuItemMethod.cs
+++ b/src/Microsoft.Unity.Analyzers/ImproperMenuItemMethod.cs
@@ -76,7 +76,7 @@ public class ImproperMenuItemMethodCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.ImproperMenuItemMethodCodeFixTitle,
 				ct => AddStaticDeclarationAsync(context.Document, declaration, ct),
-				declaration.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/ImproperMessageCase.cs
+++ b/src/Microsoft.Unity.Analyzers/ImproperMessageCase.cs
@@ -115,7 +115,7 @@ public class ImproperMessageCaseCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.ImproperMessageCaseCodeFixTitle,
 				ct => FixMessageCaseAsync(context.Document, declaration, ct),
-				declaration.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/ImproperSerializeField.cs
+++ b/src/Microsoft.Unity.Analyzers/ImproperSerializeField.cs
@@ -105,7 +105,7 @@ public class ImproperSerializeFieldCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.ImproperSerializeFieldCodeFixTitle,
 				ct => RemoveSerializeFieldAttributeAsync(context.Document, declaration, ct),
-				declaration.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/IndirectionMessage.cs
+++ b/src/Microsoft.Unity.Analyzers/IndirectionMessage.cs
@@ -4,6 +4,7 @@
  *-------------------------------------------------------------------------------------------*/
 
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -82,7 +83,7 @@ public class IndirectionMessageCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.IndirectionMessageCodeFixTitle,
 				ct => DeleteIndirectionAsync(context.Document, access, ct),
-				access.Expression.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/InitializeOnLoadStaticCtor.cs
+++ b/src/Microsoft.Unity.Analyzers/InitializeOnLoadStaticCtor.cs
@@ -85,7 +85,7 @@ public class InitializeOnLoadStaticCtorCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.InitializeOnLoadStaticCtorCodeFixTitle,
 				ct => CreateStaticCtorAsync(context.Document, classDeclaration, ct),
-				classDeclaration.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/InputGetKey.cs
+++ b/src/Microsoft.Unity.Analyzers/InputGetKey.cs
@@ -146,7 +146,7 @@ public class InputGetKeyCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.InputGetKeyCodeFixTitle,
 				ct => UseKeyCodeMemberAsArgumentAsync(context.Document, invocation, ct),
-				invocation.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/LoadAttributeMethod.cs
+++ b/src/Microsoft.Unity.Analyzers/LoadAttributeMethod.cs
@@ -106,7 +106,7 @@ public class LoadAttributeMethodCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.LoadAttributeMethodCodeFixTitle,
 				ct => FixMethodAsync(context.Document, methodDeclaration, ct),
-				methodDeclaration.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/MessageSignature.cs
+++ b/src/Microsoft.Unity.Analyzers/MessageSignature.cs
@@ -108,7 +108,7 @@ public class MessageSignatureCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.MessageSignatureCodeFixTitle,
 				ct => FixMethodDeclarationSignatureAsync(context.Document, methodDeclaration, ct),
-				methodDeclaration.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
+++ b/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
@@ -128,7 +128,7 @@ public abstract class BaseMethodInvocationCodeFix(string title) : CodeFixProvide
 			CodeAction.Create(
 				title,
 				ct => ChangeArgumentAsync(context.Document, invocation, ct),
-				invocation.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/NonGenericGetComponent.cs
+++ b/src/Microsoft.Unity.Analyzers/NonGenericGetComponent.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -105,7 +106,7 @@ public class NonGenericGetComponentCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.NonGenericGetComponentCodeFixTitle,
 				ct => UseGenericGetComponentAsync(context.Document, invocation, ct),
-				invocation.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/PropertyDrawerOnGUI.cs
+++ b/src/Microsoft.Unity.Analyzers/PropertyDrawerOnGUI.cs
@@ -4,6 +4,7 @@
  *-------------------------------------------------------------------------------------------*/
 
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -77,7 +78,7 @@ public class PropertyDrawerOnGUICodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.PropertyDrawerOnGUICodeFixTitle,
 				ct => RemoveInvocationAsync(context.Document, invocation, ct),
-				invocation.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/ProtectedUnityMessage.cs
+++ b/src/Microsoft.Unity.Analyzers/ProtectedUnityMessage.cs
@@ -4,6 +4,7 @@
  *-------------------------------------------------------------------------------------------*/
 
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -93,7 +94,7 @@ public class ProtectedUnityMessageCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.ProtectedUnityMessageCodeFixTitle,
 				ct => MakeMessageProtectedAsync(context.Document, declaration, ct),
-				declaration.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/TagComparison.cs
+++ b/src/Microsoft.Unity.Analyzers/TagComparison.cs
@@ -153,7 +153,7 @@ public class TagComparisonCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.TagComparisonCodeFixTitle,
 				action,
-				node.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/TryGetComponent.cs
+++ b/src/Microsoft.Unity.Analyzers/TryGetComponent.cs
@@ -232,7 +232,8 @@ public class TryGetComponentCodeFix : CodeFixProvider
 		context.RegisterCodeFix(
 			CodeAction.Create(
 				Strings.TryGetComponentCodeFixTitle,
-				ct => ReplaceWithTryGetComponentAsync(context.Document, invocation, ct), invocation.ToFullString()),
+				ct => ReplaceWithTryGetComponentAsync(context.Document, invocation, ct),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/UnityObjectNullHandling.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityObjectNullHandling.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Unity.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class UnityObjectNullHandlingAnalyzer : DiagnosticAnalyzer
 {
-	private const string NullCoalescingRuleId = "UNT0007";
-	private const string NullPropagationRuleId = "UNT0008";
-	private const string CoalescingAssignmentRuleId = "UNT0023";
-	private const string IsPatternRuleId = "UNT0029";
+	internal const string NullCoalescingRuleId = "UNT0007";
+	internal const string NullPropagationRuleId = "UNT0008";
+	internal const string CoalescingAssignmentRuleId = "UNT0023";
+	internal const string IsPatternRuleId = "UNT0029";
 
 	internal static readonly DiagnosticDescriptor NullCoalescingRule = new(
 		id: NullCoalescingRuleId,
@@ -155,7 +155,10 @@ public class UnityObjectNullHandlingCodeFix : CodeFixProvider
 				if (HasSideEffect(bes.Left))
 					return;
 
-				action = CodeAction.Create(Strings.UnityObjectNullCoalescingCodeFixTitle, ct => ReplaceNullCoalescingAsync(context.Document, bes, ct), bes.ToFullString());
+				action = CodeAction.Create(
+					Strings.UnityObjectNullCoalescingCodeFixTitle,
+					ct => ReplaceNullCoalescingAsync(context.Document, bes, ct),
+					UnityObjectNullHandlingAnalyzer.NullCoalescingRuleId); // using DiagnosticId as equivalence key for BatchFixer
 				break;
 
 			// Null propagation
@@ -163,7 +166,10 @@ public class UnityObjectNullHandlingCodeFix : CodeFixProvider
 				if (HasSideEffect(caes.Expression))
 					return;
 
-				action = CodeAction.Create(Strings.UnityObjectNullPropagationCodeFixTitle, ct => ReplaceNullPropagationAsync(context.Document, caes, ct), caes.ToFullString());
+				action = CodeAction.Create(
+					Strings.UnityObjectNullPropagationCodeFixTitle,
+					ct => ReplaceNullPropagationAsync(context.Document, caes, ct),
+					UnityObjectNullHandlingAnalyzer.NullPropagationRuleId); // using DiagnosticId as equivalence key for BatchFixer
 				break;
 
 			// Coalescing assignment
@@ -171,7 +177,10 @@ public class UnityObjectNullHandlingCodeFix : CodeFixProvider
 				if (HasSideEffect(aes.Left))
 					return;
 
-				action = CodeAction.Create(Strings.UnityObjectCoalescingAssignmentCodeFixTitle, ct => ReplaceCoalescingAssignmentAsync(context.Document, aes, ct), aes.ToFullString());
+				action = CodeAction.Create(
+					Strings.UnityObjectCoalescingAssignmentCodeFixTitle,
+					ct => ReplaceCoalescingAssignmentAsync(context.Document, aes, ct),
+					UnityObjectNullHandlingAnalyzer.CoalescingAssignmentRuleId); // using DiagnosticId as equivalence key for BatchFixer
 				break;
 
 			// Pattern expression
@@ -179,7 +188,10 @@ public class UnityObjectNullHandlingCodeFix : CodeFixProvider
 				if (HasSideEffect(pes.Expression))
 					return;
 
-				action = CodeAction.Create(Strings.UnityObjectIsPatternCodeFixTitle, ct => ReplacePatternExpressionAsync(context.Document, pes, ct), pes.ToFullString());
+				action = CodeAction.Create(
+					Strings.UnityObjectIsPatternCodeFixTitle,
+					ct => ReplacePatternExpressionAsync(context.Document, pes, ct),
+					UnityObjectNullHandlingAnalyzer.IsPatternRuleId); // using DiagnosticId as equivalence key for BatchFixer
 				break;
 
 			default:

--- a/src/Microsoft.Unity.Analyzers/UnusedCoroutineReturnValue.cs
+++ b/src/Microsoft.Unity.Analyzers/UnusedCoroutineReturnValue.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -92,7 +93,7 @@ public class UnusedCoroutineReturnValueCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.UnusedCoroutineReturnValueCodeFixTitle,
 				ct => WrapWithStartCoroutineAsync(context.Document, parent, invocation, ct),
-				invocation.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/UpdateDeltaTime.cs
+++ b/src/Microsoft.Unity.Analyzers/UpdateDeltaTime.cs
@@ -126,7 +126,7 @@ public class UpdateDeltaTimeCodeFix : CodeFixProvider
 					CodeAction.Create(
 						Strings.UpdateWithoutFixedDeltaTimeCodeFixTitle,
 						ct => ReplaceDeltaTimeIdentifierAsync(context.Document, identifierName, "deltaTime", ct),
-						identifierName.ToFullString()),
+						diagnostic.Id), // using DiagnosticId as equivalence key for BatchFixer
 					context.Diagnostics);
 				break;
 			case UpdateDeltaTimeAnalyzer.FixedUpdateId:
@@ -134,7 +134,7 @@ public class UpdateDeltaTimeCodeFix : CodeFixProvider
 					CodeAction.Create(
 						Strings.FixedUpdateWithoutDeltaTimeCodeFixTitle,
 						ct => ReplaceDeltaTimeIdentifierAsync(context.Document, identifierName, "fixedDeltaTime", ct),
-						identifierName.ToFullString()),
+						diagnostic.Id), // using DiagnosticId as equivalence key for BatchFixer
 					context.Diagnostics);
 				break;
 		}

--- a/src/Microsoft.Unity.Analyzers/VectorMath.cs
+++ b/src/Microsoft.Unity.Analyzers/VectorMath.cs
@@ -168,7 +168,7 @@ public class VectorMathCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.VectorMathCodeFixTitle,
 				ct => FixOperandOrderAsync(context.Document, node, ct),
-				node.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 


### PR DESCRIPTION
Fixes #308 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Fix BatchFixer for UNT0021 (and audit/fix for others)

#### Changes proposed in this pull request:
We are using the default BatchFixer provided by Roslyn.
See the documentation here:
https://github.com/dotnet/roslyn/blob/main/docs/analyzers/FixAllProvider.md

We were wrongly setting the **Equivalence Key**: A string value representing an equivalence class of all code actions registered by a code fixer or refactoring. Two code actions are treated as equivalent if they have equal EquivalenceKey values and were generated by the same code fixer or refactoring.

