### PR TITLE
Fix workflows

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -13,7 +13,14 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-latest
-    
+    permissions:
+      actions: read
+      contents: read
+      deployments: read
+      packages: none
+      pull-requests: write
+      security-events: write
+
     steps:
     - name: Checkout 
       uses: actions/checkout@v1

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -13,7 +13,14 @@ on:
 jobs:
   macos:
     runs-on: macos-latest
-    
+    permissions:
+      actions: read
+      contents: read
+      deployments: read
+      packages: none
+      pull-requests: write
+      security-events: write
+
     steps:
     - name: Checkout 
       uses: actions/checkout@v1

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -13,7 +13,14 @@ on:
 jobs:
   windows:
     runs-on: windows-latest
-    
+    permissions:
+      actions: read
+      contents: read
+      deployments: read
+      packages: none
+      pull-requests: write
+      security-events: write
+
     steps:
     - name: Checkout 
       uses: actions/checkout@v1


### PR DESCRIPTION
#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;

#### Short description of what this resolves:
Starting February 1, 2024 the default token access for the `GITHUB_TOKEN`, which is used for all GitHub Actions workflows, will be changing from Read/Write to Read-only for its default access. You will need to make [adjustments to your workflows](https://docs.opensource.microsoft.com/github/apps/permission-changes/#what-steps-must-i-take-to-avoid-a-bad-time) by adding a permissions block and detailing the levels of access to the [required scopes](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#permissions) . Failure to make adjustments to your workflows will break your workflows that require any permission above Read.

See https://docs.opensource.microsoft.com/github/apps/permission-changes/