### PR TITLE
Fix UNT0006 when a Unity message is wrongly referenced.

### DIFF
--- a/src/Microsoft.Unity.Analyzers/MessageSignature.cs
+++ b/src/Microsoft.Unity.Analyzers/MessageSignature.cs
@@ -100,14 +100,18 @@ public class MessageSignatureCodeFix : CodeFixProvider
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{
-		var methodDeclaration = await context.GetFixableNodeAsync<MethodDeclarationSyntax>();
-		if (methodDeclaration == null)
+		var method = await context.GetFixableNodeAsync<MethodDeclarationSyntax>();
+		if (method == null)
+			return;
+
+		// Do not provide a code fix if the message is -wrongly- referenced elsewhere
+		if (await context.IsReferencedAsync(method))
 			return;
 
 		context.RegisterCodeFix(
 			CodeAction.Create(
 				Strings.MessageSignatureCodeFixTitle,
-				ct => FixMethodDeclarationSignatureAsync(context.Document, methodDeclaration, ct),
+				ct => FixMethodDeclarationSignatureAsync(context.Document, method, ct),
 				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}


### PR DESCRIPTION
Fixes #362

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Fix UNT0006 when a Unity message is wrongly referenced.