### PR TITLE
Fix syntax issue in UNT0002.md

### DIFF
--- a/doc/UNT0002.md
+++ b/doc/UNT0002.md
@@ -11,7 +11,7 @@ public class Camera : MonoBehaviour
 {
     private void Update()
     {
-        Debug.Log(tag == ""tag1"");
+        Debug.Log(tag == "tag1");
     }
 }
 ```
@@ -27,7 +27,7 @@ public class Camera : MonoBehaviour
 {
     private void Update()
     {
-        Debug.Log(CompareTag(""tag1""));
+        Debug.Log(CompareTag("tag1"));
     }
 }
 ```


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #378

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
There was double double-quote in string for a 6 years old doc file that's been still being linked in Visual Studio.

#### Changes proposed in this pull request:
<!--Fill These Bullet Points-->
- make them single double-quote `"` in both end of the string
