### PR TITLE
Remove legacy filters

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/AnalyzerVerificationContext.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/AnalyzerVerificationContext.cs
@@ -14,11 +14,9 @@ public readonly struct AnalyzerVerificationContext(ImmutableDictionary<string, s
 	public ImmutableArray<string> Filters { get; } = filters;
 	public LanguageVersion LanguageVersion { get; } = languageVersion;
 
-	// CS1701 - Assuming assembly reference 'mscorlib, Version=2.0.0.0' used by 'UnityEngine' matches identity 'mscorlib, Version=4.0.0.0' of 'mscorlib', you may need to supply runtime policy
-	// CS0414 - cf. IDE0051
 	public static AnalyzerVerificationContext Default = new(
 		ImmutableDictionary<string, string>.Empty,
-		["CS1701", "CS0414"],
+		[],
 		LanguageVersion.Latest);
 
 	public AnalyzerVerificationContext WithAnalyzerOption(string key, string value)

--- a/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/AnalyzerVerificationContext.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/Infrastructure/AnalyzerVerificationContext.cs
@@ -14,9 +14,10 @@ public readonly struct AnalyzerVerificationContext(ImmutableDictionary<string, s
 	public ImmutableArray<string> Filters { get; } = filters;
 	public LanguageVersion LanguageVersion { get; } = languageVersion;
 
+	// CS0414 - cf. IDE0051
 	public static AnalyzerVerificationContext Default = new(
 		ImmutableDictionary<string, string>.Empty,
-		[],
+		["CS0414"],
 		LanguageVersion.Latest);
 
 	public AnalyzerVerificationContext WithAnalyzerOption(string key, string value)


### PR DESCRIPTION
Those test-wide filters are not needed anymore with Unity 6

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
