### PR TITLE
UNT0039 Use `RequireComponent` attribute when self-invoking `GetComponent`

### DIFF
--- a/doc/UNT0039.md
+++ b/doc/UNT0039.md
@@ -1,0 +1,40 @@
+# UNT0039 Use `RequireComponent` attribute when self-invoking `GetComponent`
+
+The `RequireComponent` attribute automatically adds required components as dependencies.
+
+When you add a script which uses `RequireComponent` to a `GameObject`, the required component is automatically added to the `GameObject`. This is useful to avoid setup errors. For example a script might require that a `Rigidbody` is always added to the same `GameObject`. When you use `RequireComponent`, this is done automatically, so you are unlikely to get the setup wrong.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using UnityEngine;
+
+public class PlayerScript : MonoBehaviour
+{
+    void Start()
+    {
+        var rb = GetComponent<Rigidbody>();
+        ...
+    }
+}
+```
+
+## Solution
+
+Use `RequiredComponent` attribute:
+
+```csharp
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody))]
+public class PlayerScript : MonoBehaviour
+{
+    void Start()
+    {
+        var rb = GetComponent<Rigidbody>();
+        ...
+    }
+}
+```
+
+A code fix is offered for this diagnostic to automatically apply this change.

--- a/doc/index.md
+++ b/doc/index.md
@@ -40,6 +40,7 @@ ID | Title | Category
 [UNT0036](UNT0036.md) | Inefficient method to get position and rotation | Performance
 [UNT0037](UNT0037.md) | Inefficient method to get localPosition and localRotation | Performance
 [UNT0038](UNT0038.md) | Cache `WaitForSeconds` invocations | Performance
+[UNT0039](UNT0039.md) | Use `RequireComponent` attribute when self-invoking `GetComponent` | Type Safety
 
 # Diagnostic Suppressors
 

--- a/src/Microsoft.Unity.Analyzers.Tests/CacheYieldInstructionAnalyzerTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/CacheYieldInstructionAnalyzerTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Unity.Analyzers.Tests;
 public class CacheYieldInstructionAnalyzerTests : BaseCodeFixVerifierTest<CacheYieldInstructionAnalyzerAnalyzer, CacheYieldInstructionAnalyzerCodeFix>
 {
 	[Fact]
-	public async Task WaitForSecondsStaticAsync()
+	public async Task WaitForSecondsStatic()
 	{
 		const string test = @"
 using System.Collections;
@@ -50,7 +50,7 @@ class Camera : MonoBehaviour
 	}
 
 	[Fact]
-	public async Task WaitForSecondsStaticTriviaAsync()
+	public async Task WaitForSecondsStaticTrivia()
 	{
 		const string test = @"
 using System.Collections;
@@ -102,7 +102,7 @@ class Camera : MonoBehaviour
 
 
 	[Fact]
-	public async Task WaitForSecondsOnlyLiteralAsync()
+	public async Task WaitForSecondsOnlyLiteral()
 	{
 		const string test = @"
 using System.Collections;
@@ -122,7 +122,7 @@ class Camera : MonoBehaviour
 	}
 
 	[Fact]
-	public async Task WaitForSecondsMultipleAsync()
+	public async Task WaitForSecondsMultiple()
 	{
 		const string test = @"
 using System.Collections;
@@ -175,7 +175,7 @@ class Camera : MonoBehaviour
 	}
 
 	[Fact]
-	public async Task WaitForSecondsReuseAsync()
+	public async Task WaitForSecondsReuse()
 	{
 		const string test = @"
 using System.Collections;
@@ -227,7 +227,7 @@ class Camera : MonoBehaviour
 	}
 
 	[Fact]
-	public async Task WaitForSecondsAndRealtimeAsync()
+	public async Task WaitForSecondsAndRealtime()
 	{
 		const string test = @"
 using System.Collections;

--- a/src/Microsoft.Unity.Analyzers.Tests/RequireComponentTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/RequireComponentTests.cs
@@ -1,0 +1,170 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests;
+
+public class RequireComponentTests : BaseCodeFixVerifierTest<RequireComponentAnalyzer, RequireComponentCodeFix>
+{
+	[Fact]
+	public async Task GetComponent()
+	{
+		const string test = @"
+using UnityEngine;
+
+public class PlayerScript : MonoBehaviour
+{
+    void Start()
+    {
+        var rb = GetComponent<Rigidbody>();
+    }
+}";
+
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(8, 18);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody))]
+public class PlayerScript : MonoBehaviour
+{
+    void Start()
+    {
+        var rb = GetComponent<Rigidbody>();
+    }
+}";
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task ThisGetComponent()
+	{
+		const string test = @"
+using UnityEngine;
+
+public class PlayerScript : MonoBehaviour
+{
+    void Start()
+    {
+        var rb = this.GetComponent<Rigidbody>();
+    }
+}";
+
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(8, 18);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody))]
+public class PlayerScript : MonoBehaviour
+{
+    void Start()
+    {
+        var rb = this.GetComponent<Rigidbody>();
+    }
+}";
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task MonoBehaviourInstance()
+	{
+		const string test = @"
+using UnityEngine;
+
+public class FooComponent : Component
+{
+    void Foo()
+    {
+        var rb = this.GetComponent<Rigidbody>();
+    }
+}";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task ThisType()
+	{
+		const string test = @"
+using UnityEngine;
+
+public class PlayerScript : MonoBehaviour
+{
+    void Start()
+    {
+		var foo = new GameObject();
+        var rb = foo.GetComponent<Rigidbody>();
+    }
+}";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task AlreadyRequired()
+	{
+		const string test = @"
+using UnityEngine;
+
+[RequireComponent(typeof(object))]
+[RequireComponent(typeof(object), typeof(Rigidbody))]
+public class PlayerScript : MonoBehaviour
+{
+    void Start()
+    {
+        var rb = GetComponent<Rigidbody>();
+    }
+}";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task InvocationNullChecked()
+	{
+		const string test = @"
+using UnityEngine;
+
+public class PlayerScript : MonoBehaviour
+{
+    void Start()
+    {
+        if (GetComponent<Rigidbody>() == null) {
+        }
+    }
+}";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task InvocationNotNullChecked()
+	{
+		const string test = @"
+using UnityEngine;
+
+public class PlayerScript : MonoBehaviour
+{
+    void Start()
+    {
+        if (null != GetComponent<Rigidbody>()) {
+        }
+    }
+}";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+}

--- a/src/Microsoft.Unity.Analyzers.Tests/RequireComponentTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/RequireComponentTests.cs
@@ -105,7 +105,7 @@ public class PlayerScript : MonoBehaviour
 {
     void Start()
     {
-		var foo = new GameObject();
+        var foo = new GameObject();
         var rb = foo.GetComponent<Rigidbody>();
     }
 }";
@@ -181,32 +181,6 @@ class Camera : MonoBehaviour
         var rb = gameObject.GetComponent<Rigidbody>();
         if (rb != null) {
             Debug.Log(rb.name);
-        }
-    }
-}
-";
-
-		await VerifyCSharpDiagnosticAsync(test);
-	}
-
-	[Fact]
-	public async Task VariableDeclarationScopeTest()
-	{
-		const string test = @"
-using UnityEngine;
-
-class Camera : MonoBehaviour
-{
-    public void Update() 
-    {
-        if (true) {
-            var rb = gameObject.GetComponent<Rigidbody>();
-            if (rb != null) {
-                Debug.Log(rb.name);
-            }
-            if (rb == null) {
-                Debug.Log(""null"");
-            }
         }
     }
 }

--- a/src/Microsoft.Unity.Analyzers.Tests/RequireComponentTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/RequireComponentTests.cs
@@ -167,4 +167,137 @@ public class PlayerScript : MonoBehaviour
 
 		await VerifyCSharpDiagnosticAsync(test);
 	}
+
+	[Fact]
+	public async Task VariableDeclarationNotNullConditionTest()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public void Update() 
+    {
+        var rb = gameObject.GetComponent<Rigidbody>();
+        if (rb != null) {
+            Debug.Log(rb.name);
+        }
+    }
+}
+";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task VariableDeclarationScopeTest()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public void Update() 
+    {
+        if (true) {
+            var rb = gameObject.GetComponent<Rigidbody>();
+            if (rb != null) {
+                Debug.Log(rb.name);
+            }
+            if (rb == null) {
+                Debug.Log(""null"");
+            }
+        }
+    }
+}
+";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task VariableDeclarationNotNullConditionReverseOperandsTest()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public void Update() 
+    {
+        var rb = gameObject.GetComponent<Rigidbody>();
+        if (null != rb) {
+            Debug.Log(rb.name);
+        }
+    }
+}
+";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task VariableDeclarationNullConditionTest()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public void Update() 
+    {
+        var rb = gameObject.GetComponent<Rigidbody>();
+        if (rb == null) {
+            Debug.Log(""null!"");
+        }
+    }
+}
+";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task PropertyAssignmentNotNullConditionTest()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    private Rigidbody rb { get; set;}
+
+    public void Update() 
+    {
+        rb = gameObject.GetComponent<Rigidbody>();
+        if (rb != null) {
+            Debug.Log(rb.name);
+        }
+    }
+}
+";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task NoGetComponentDerivatives()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    public void Update() 
+    {
+        var rb = gameObject.GetComponentInChildren<Rigidbody>();
+        if (rb != null) {
+            Debug.Log(rb.name);
+        }
+    }
+}
+";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
 }

--- a/src/Microsoft.Unity.Analyzers/BaseGetComponentAnalyzer.cs
+++ b/src/Microsoft.Unity.Analyzers/BaseGetComponentAnalyzer.cs
@@ -1,0 +1,96 @@
+﻿/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.Unity.Analyzers
+{
+	public abstract class BaseGetComponentAnalyzer : DiagnosticAnalyzer
+	{
+		internal static bool IsGenericGetComponent(InvocationExpressionSyntax invocation, SemanticModel model, [NotNullWhen(true)] out IMethodSymbol? method)
+		{
+			method = null;
+
+			// We are looking for the exact GetComponent method, not other derivatives, so we do not want to use KnownMethods.IsGetComponentName(nameSyntax)
+			if (invocation.GetMethodNameSyntax() is not { Identifier.Text: nameof(UnityEngine.Component.GetComponent) })
+				return false;
+
+			var symbol = ModelExtensions.GetSymbolInfo(model, invocation);
+			if (symbol.Symbol is not IMethodSymbol methodSymbol)
+				return false;
+
+			method = methodSymbol;
+
+			// We want Component.GetComponent or GameObject.GetComponent (given we already checked the exact name, we can use this one)
+			if (!KnownMethods.IsGetComponent(method))
+				return false;
+
+			// We don't want arguments
+			if (invocation.ArgumentList.Arguments.Count != 0)
+				return false;
+
+			// We want a type argument
+			return method.TypeArguments.Length == 1;
+		}
+
+		protected static bool IsNonGenericGetComponent(InvocationExpressionSyntax invocation, SemanticModel model, [NotNullWhen(true)] out IMethodSymbol? method)
+		{
+			method = null;
+
+			var symbol = ModelExtensions.GetSymbolInfo(model, invocation);
+			if (symbol.Symbol is not IMethodSymbol methodSymbol)
+				return false;
+
+			method = methodSymbol;
+			if (!KnownMethods.IsGetComponent(method))
+				return false;
+
+			return method.Parameters.Length != 0 && method.Parameters[0].Type.Matches(typeof(Type));
+		}
+
+		protected static bool HasInvalidTypeArgument(IMethodSymbol method, out string? identifier)
+		{
+			identifier = null;
+			var argumentType = method.TypeArguments.FirstOrDefault();
+			if (argumentType == null)
+				return false;
+
+			if (IsComponentOrInterface(argumentType))
+				return false;
+
+			if (argumentType.TypeKind == TypeKind.TypeParameter && argumentType is ITypeParameterSymbol typeParameter)
+			{
+				// We need to infer the effective generic type given usage, but we don't do that yet.
+				if (typeParameter.ConstraintTypes.IsEmpty)
+					return false;
+
+				if (typeParameter.ConstraintTypes.Any(IsComponentOrInterface))
+					return false;
+			}
+
+			identifier = argumentType.Name;
+			return true;
+		}
+
+		protected static bool IsComponentOrInterface(ITypeSymbol argumentType)
+		{
+			return argumentType.Extends(typeof(UnityEngine.Component)) || argumentType.TypeKind == TypeKind.Interface;
+		}
+
+		protected static bool IsTryGetComponentSupported(SyntaxNodeAnalysisContext context)
+		{
+			// We need Unity 2019.2+ for proper support
+			var goType = context.Compilation.GetTypeByMetadataName(typeof(UnityEngine.GameObject).FullName!);
+			return goType?.MemberNames.Contains(nameof(UnityEngine.Component.TryGetComponent)) ?? false;
+		}
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/CacheYieldInstructionAnalyzer.cs
+++ b/src/Microsoft.Unity.Analyzers/CacheYieldInstructionAnalyzer.cs
@@ -92,7 +92,7 @@ public class CacheYieldInstructionAnalyzerCodeFix : CodeFixProvider
 			CodeAction.Create(
 				Strings.CacheYieldInstructionAnalyzerCodeFixTitle,
 				ct => CacheYieldInstructionAsync(context.Document, objectCreation, ct),
-				objectCreation.ToFullString()),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 			context.Diagnostics);
 	}
 

--- a/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
+++ b/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
@@ -4,7 +4,6 @@
  *-------------------------------------------------------------------------------------------*/
 
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -14,7 +13,7 @@ using Microsoft.Unity.Analyzers.Resources;
 namespace Microsoft.Unity.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class GetComponentIncorrectTypeAnalyzer : DiagnosticAnalyzer
+public class GetComponentIncorrectTypeAnalyzer : BaseGetComponentAnalyzer
 {
 	private const string RuleId = "UNT0014";
 
@@ -59,34 +58,5 @@ public class GetComponentIncorrectTypeAnalyzer : DiagnosticAnalyzer
 			return;
 
 		context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), identifier));
-	}
-
-	private static bool HasInvalidTypeArgument(IMethodSymbol method, out string? identifier)
-	{
-		identifier = null;
-		var argumentType = method.TypeArguments.FirstOrDefault();
-		if (argumentType == null)
-			return false;
-
-		if (IsComponentOrInterface(argumentType))
-			return false;
-
-		if (argumentType.TypeKind == TypeKind.TypeParameter && argumentType is ITypeParameterSymbol typeParameter)
-		{
-			// We need to infer the effective generic tye given usage, but we don't do that yet.
-			if (typeParameter.ConstraintTypes.IsEmpty)
-				return false;
-
-			if (typeParameter.ConstraintTypes.Any(IsComponentOrInterface))
-				return false;
-		}
-
-		identifier = argumentType.Name;
-		return true;
-	}
-
-	private static bool IsComponentOrInterface(ITypeSymbol argumentType)
-	{
-		return argumentType.Extends(typeof(UnityEngine.Component)) || argumentType.TypeKind == TypeKind.Interface;
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/RequireComponent.cs
+++ b/src/Microsoft.Unity.Analyzers/RequireComponent.cs
@@ -1,0 +1,158 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.Unity.Analyzers.Resources;
+using UnityEngine;
+
+namespace Microsoft.Unity.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RequireComponentAnalyzer : BaseGetComponentAnalyzer
+{
+	private const string RuleId = "UNT0039";
+
+	internal static readonly DiagnosticDescriptor Rule = new(
+		id: RuleId,
+		title: Strings.RequireComponentAnalyzerDiagnosticTitle,
+		messageFormat: Strings.RequireComponentAnalyzerDiagnosticMessageFormat,
+		category: DiagnosticCategory.TypeSafety,
+		defaultSeverity: DiagnosticSeverity.Info,
+		isEnabledByDefault: true,
+		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
+		description: Strings.RequireComponentAnalyzerDiagnosticDescription);
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+	public override void Initialize(AnalysisContext context)
+	{
+		context.EnableConcurrentExecution();
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+		context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+	}
+
+	private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+	{
+		var invocation = (InvocationExpressionSyntax)context.Node;
+
+		var model = context.SemanticModel;
+		if (!IsGenericGetComponent(invocation, model, out var method))
+			return;
+
+		if (model.GetOperation(invocation) is not IInvocationOperation invocationOperation)
+			return;
+
+		if (invocationOperation.Instance is not IInstanceReferenceOperation referenceOperation)
+			return;
+
+		var containerType = referenceOperation.Type;
+		if (containerType == null)
+			return;
+
+		if (!containerType.Extends(typeof(MonoBehaviour)))
+			return;
+
+		var componentType = method.TypeArguments.First(); // Checked by IsGenericGetComponent
+		if (IsTypeAlreadyRequired(containerType, componentType))
+			return;
+
+		if (IsInvocationNullChecked(invocation))
+			return;
+
+		context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
+	}
+
+	private static bool IsTypeAlreadyRequired(ITypeSymbol containerType, ITypeSymbol componentType)
+	{
+		var typeSymbols = containerType
+			.GetAttributes()
+			.Where(a => a.AttributeClass != null && a.AttributeClass.Matches(typeof(RequireComponent)))
+			.SelectMany(a => a.ConstructorArguments)
+			.Select(ca => ca.Value)
+			.OfType<ISymbol>();
+
+		return typeSymbols.Any(ts => SymbolEqualityComparer.Default.Equals(ts, componentType));
+	}
+
+	private static bool IsInvocationNullChecked(InvocationExpressionSyntax invocation)
+	{
+		var parent = invocation.Parent;
+		return parent switch
+		{
+			BinaryExpressionSyntax binary when
+				(binary.IsKind(SyntaxKind.EqualsExpression) || binary.IsKind(SyntaxKind.NotEqualsExpression))
+				&& (binary.Right.IsKind(SyntaxKind.NullLiteralExpression) || binary.Left.IsKind(SyntaxKind.NullLiteralExpression)) => true,
+			_ => false,
+		};
+	}
+}
+
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+public class RequireComponentCodeFix : CodeFixProvider
+{
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => [RequireComponentAnalyzer.Rule.Id];
+
+	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+	{
+		var invocation = await context.GetFixableNodeAsync<InvocationExpressionSyntax>();
+		if (invocation == null)
+			return;
+
+		var classDeclaration = invocation.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+		if (classDeclaration == null)
+			return;
+
+		var model = await context.Document.GetSemanticModelAsync(context.CancellationToken);
+		if (model == null)
+			return;
+
+		var symbol = model.GetSymbolInfo(invocation);
+		if (symbol.Symbol is not IMethodSymbol method)
+			return;
+
+		var typeName = method.TypeArguments.First().ToDisplayString();
+
+		context.RegisterCodeFix(
+			CodeAction.Create(
+				Strings.RequireComponentAnalyzerCodeFixTitle,
+				ct => AddRequiredComponentAsync(context.Document, classDeclaration, typeName, ct),
+				FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
+			context.Diagnostics);
+	}
+
+	private static async Task<Document> AddRequiredComponentAsync(Document document, ClassDeclarationSyntax classDeclaration, string typeName, CancellationToken cancellationToken)
+	{
+		var attribute = SyntaxFactory.Attribute(
+			SyntaxFactory.ParseName(typeof(RequireComponent).FullName!),
+			SyntaxFactory.AttributeArgumentList(
+				SyntaxFactory.SingletonSeparatedList(
+					SyntaxFactory.AttributeArgument(
+						SyntaxFactory.TypeOfExpression(SyntaxFactory.ParseTypeName(typeName))))))
+			.WithAdditionalAnnotations(Simplifier.Annotation);
+
+		var newClassDeclaration = classDeclaration.AddAttributeLists(
+			SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(attribute)));
+
+		var root = await document.GetSyntaxRootAsync(cancellationToken);
+		if (root == null)
+			return document;
+
+		var newRoot = root.ReplaceNode(classDeclaration, newClassDeclaration);
+		return document.WithSyntaxRoot(newRoot);
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/RequireComponent.cs
+++ b/src/Microsoft.Unity.Analyzers/RequireComponent.cs
@@ -72,6 +72,16 @@ public class RequireComponentAnalyzer : BaseGetComponentAnalyzer
 		if (IsInvocationNullChecked(invocation))
 			return;
 
+		var invocationParent = invocation.Parent;
+		if (invocationParent == null)
+			return;
+
+		if (TryGetTargetdentifier(invocationParent, out var targetIdentifier)
+			&& TryGetNextTopNode(invocationParent, out var ifNode)
+			&& TryGetConditionIdentifier(ifNode, out var conditionIdentifier, out _, out _)
+			&& conditionIdentifier.Value.Text != targetIdentifier.Value.Text)
+			return;
+
 		context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
 	}
 

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -961,6 +961,42 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use RequireComponent attribute.
+        /// </summary>
+        internal static string RequireComponentAnalyzerCodeFixTitle {
+            get {
+                return ResourceManager.GetString("RequireComponentAnalyzerCodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The RequireComponent attribute automatically adds required components as dependencies..
+        /// </summary>
+        internal static string RequireComponentAnalyzerDiagnosticDescription {
+            get {
+                return ResourceManager.GetString("RequireComponentAnalyzerDiagnosticDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use RequireComponent attribute when self-invoking GetComponent.
+        /// </summary>
+        internal static string RequireComponentAnalyzerDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("RequireComponentAnalyzerDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use RequireComponent attribute when self-invoking GetComponent.
+        /// </summary>
+        internal static string RequireComponentAnalyzerDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("RequireComponentAnalyzerDiagnosticTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use SetLocalPositionAndRotation() method.
         /// </summary>
         internal static string SetLocalPositionAndRotationCodeFixTitle {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -626,4 +626,16 @@
   <data name="CacheYieldInstructionAnalyzerDiagnosticTitle" xml:space="preserve">
     <value>WaitForSeconds caching </value>
   </data>
+  <data name="RequireComponentAnalyzerCodeFixTitle" xml:space="preserve">
+    <value>Use RequireComponent attribute</value>
+  </data>
+  <data name="RequireComponentAnalyzerDiagnosticDescription" xml:space="preserve">
+    <value>The RequireComponent attribute automatically adds required components as dependencies.</value>
+  </data>
+  <data name="RequireComponentAnalyzerDiagnosticMessageFormat" xml:space="preserve">
+    <value>Use RequireComponent attribute when self-invoking GetComponent</value>
+  </data>
+  <data name="RequireComponentAnalyzerDiagnosticTitle" xml:space="preserve">
+    <value>Use RequireComponent attribute when self-invoking GetComponent</value>
+  </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/TryGetComponent.cs
+++ b/src/Microsoft.Unity.Analyzers/TryGetComponent.cs
@@ -4,7 +4,6 @@
  *-------------------------------------------------------------------------------------------*/
 
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -75,15 +74,15 @@ internal class TryGetComponentContext(string targetIdentifier, IfStatementSyntax
 		if (invocationParent == null)
 			return null;
 
-		if (!TryGetTargetdentifier(invocationParent, out var targetIdentifier))
+		if (!BaseGetComponentAnalyzer.TryGetTargetdentifier(invocationParent, out var targetIdentifier))
 			return null;
 
 		// We want the next line to be an if statement
-		if (!TryGetNextTopNode(invocationParent, out var ifNode))
+		if (!BaseGetComponentAnalyzer.TryGetNextTopNode(invocationParent, out var ifNode))
 			return null;
 
 		// We want a binary expression
-		if (!TryGetConditionIdentifier(ifNode, out var conditionIdentifier, out var binaryExpression, out var ifStatement))
+		if (!BaseGetComponentAnalyzer.TryGetConditionIdentifier(ifNode, out var conditionIdentifier, out var binaryExpression, out var ifStatement))
 			return null;
 
 		// Reusing the same identifier
@@ -104,68 +103,6 @@ internal class TryGetComponentContext(string targetIdentifier, IfStatementSyntax
 		}
 
 		return new TryGetComponentContext(targetIdentifier.Value.Text, ifStatement, binaryExpression.Kind());
-	}
-
-	private static bool TryGetConditionIdentifier(SyntaxNode ifNode, [NotNullWhen(true)] out SyntaxToken? conditionIdentifier, [NotNullWhen(true)] out BinaryExpressionSyntax? foundBinaryExpression, [NotNullWhen(true)] out IfStatementSyntax? foundIfStatement)
-	{
-		foundBinaryExpression = null;
-		foundIfStatement = null;
-		conditionIdentifier = null;
-
-		if (ifNode is not IfStatementSyntax { Condition: BinaryExpressionSyntax binaryExpression } ifStatement)
-			return false;
-
-		foundBinaryExpression = binaryExpression;
-		foundIfStatement = ifStatement;
-
-		// We want an Equals/NotEquals condition
-		if (!binaryExpression.IsKind(SyntaxKind.EqualsExpression) &&
-			!binaryExpression.IsKind(SyntaxKind.NotEqualsExpression))
-			return false;
-
-		// We want IdentifierNameSyntax and null as operands
-		conditionIdentifier = binaryExpression.Left switch
-		{
-			IdentifierNameSyntax leftIdentifierName when binaryExpression.Right is LiteralExpressionSyntax { RawKind: (int)SyntaxKind.NullLiteralExpression } => leftIdentifierName.Identifier,
-			LiteralExpressionSyntax { RawKind: (int)SyntaxKind.NullLiteralExpression } when binaryExpression.Right is IdentifierNameSyntax rightIdentifierName => rightIdentifierName.Identifier,
-			_ => null
-		};
-
-		return conditionIdentifier.HasValue;
-	}
-
-	private static bool TryGetTargetdentifier(SyntaxNode invocationParent, [NotNullWhen(true)] out SyntaxToken? targetIdentifier)
-	{
-		targetIdentifier = null;
-
-		if (invocationParent is not EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax variableDeclarator })
-			return false;
-
-		targetIdentifier = variableDeclarator.Identifier;
-		return true;
-	}
-
-	private static bool TryGetNextTopNode(SyntaxNode node, [NotNullWhen(true)] out SyntaxNode? nextNode)
-	{
-		nextNode = null;
-		var topNode = node;
-		while (topNode.Parent != null && topNode.Parent is not BlockSyntax)
-			topNode = topNode.Parent;
-
-		if (topNode.Parent is not BlockSyntax block)
-			return false;
-
-		var siblingsAndSelf = block.ChildNodes().ToImmutableArray();
-		var invocationIndex = siblingsAndSelf.IndexOf(topNode);
-		if (invocationIndex == -1)
-			return false;
-
-		var ifIndex = invocationIndex + 1;
-		if (ifIndex >= siblingsAndSelf.Length)
-			return false;
-
-		nextNode = siblingsAndSelf[ifIndex];
-		return true;
 	}
 }
 

--- a/src/Microsoft.Unity.Analyzers/UnityStubs.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityStubs.cs
@@ -599,6 +599,8 @@ namespace UnityEngine
 		[PhysicsAllocMethodUsage] static RaycastHit[] BoxCastAll(Vector3 center, Vector3 halfExtents, Vector3 direction, Quaternion orientation) { return null; }
 		[PhysicsAllocMethodUsage] static RaycastHit[] BoxCastAll(Vector3 center, Vector3 halfExtents, Vector3 direction) { return null; }
 	}
+
+	class RequireComponent : Attribute { }
 }
 
 namespace UnityEngine.EventSystems

--- a/src/new-analyzer/AnalyzerCodeFixDiagnosticBuilder.cs
+++ b/src/new-analyzer/AnalyzerCodeFixDiagnosticBuilder.cs
@@ -86,7 +86,7 @@ public class $(DiagnosticName)CodeFix : CodeFixProvider
 		//     CodeAction.Create(
 		//         Strings.$(DiagnosticName)CodeFixTitle,
 		//         ct => {},
-		//         declaration.ToFullString()),
+		//         FixableDiagnosticIds.Single()), // using DiagnosticId as equivalence key for BatchFixer
 		//     context.Diagnostics);
 	}
 }


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #35 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
UNT0039 Use `RequireComponent` attribute when self-invoking `GetComponent`