### PR TITLE
Rollback Roslyn unification

### DIFF
--- a/src/Microsoft.Unity.Analyzers/AssetOperationInLoadAttributeMethod.cs
+++ b/src/Microsoft.Unity.Analyzers/AssetOperationInLoadAttributeMethod.cs
@@ -27,14 +27,14 @@ public class AssetOperationInLoadAttributeMethodAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.AssetOperationInLoadAttributeMethodDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-	private static readonly ImmutableHashSet<string> _ignoredMembers = [
+	private static readonly ImmutableHashSet<string> _ignoredMembers = ImmutableHashSet.Create(
 		"IsAssetImportWorkerProcess",
 		"IsCacheServerEnabled",
 		"IsConnectedToCacheServer",
 		"IsDirectoryMonitoringEnabled"
-	];
+	);
 
 	public override void Initialize(AnalysisContext context)
 	{

--- a/src/Microsoft.Unity.Analyzers/CacheYieldInstructionAnalyzer.cs
+++ b/src/Microsoft.Unity.Analyzers/CacheYieldInstructionAnalyzer.cs
@@ -33,7 +33,7 @@ public class CacheYieldInstructionAnalyzerAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.CacheYieldInstructionAnalyzerDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -78,7 +78,7 @@ public class CacheYieldInstructionAnalyzerAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class CacheYieldInstructionAnalyzerCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [CacheYieldInstructionAnalyzerAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(CacheYieldInstructionAnalyzerAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/ContextMenuSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/ContextMenuSuppressor.cs
@@ -38,7 +38,7 @@ public class ContextMenuSuppressor : DiagnosticSuppressor
 		}
 	}
 
-	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => [ContextMenuRule, ContextMenuItemUnusedRule, ContextMenuItemReadonlyRule];
+	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(ContextMenuRule, ContextMenuItemUnusedRule, ContextMenuItemReadonlyRule);
 
 	private void AnalyzeDiagnostic(Diagnostic diagnostic, SuppressionAnalysisContext context)
 	{
@@ -87,7 +87,7 @@ public class ContextMenuSuppressor : DiagnosticSuppressor
 
 	private static bool IsReferencedByContextMenuItem(IMethodSymbol symbol, INamedTypeSymbol? containingType)
 	{
-		foreach (var member in containingType?.GetMembers() ?? [])
+		foreach (var member in containingType?.GetMembers() ?? Enumerable.Empty<ISymbol>())
 		{
 			if (member is not IFieldSymbol fieldSymbol)
 				continue;

--- a/src/Microsoft.Unity.Analyzers/CreateInstance.cs
+++ b/src/Microsoft.Unity.Analyzers/CreateInstance.cs
@@ -46,7 +46,7 @@ public class CreateInstanceAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(ScriptableObjectId),
 		description: Strings.CreateScriptableObjectInstanceDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [ComponentIdRule, ScriptableObjectRule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ComponentIdRule, ScriptableObjectRule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -80,7 +80,7 @@ public class CreateInstanceAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class CreateInstanceCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [CreateInstanceAnalyzer.ComponentId, CreateInstanceAnalyzer.ScriptableObjectId];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(CreateInstanceAnalyzer.ComponentId, CreateInstanceAnalyzer.ScriptableObjectId);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/DestroyTransform.cs
+++ b/src/Microsoft.Unity.Analyzers/DestroyTransform.cs
@@ -34,7 +34,7 @@ public class DestroyTransformAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.DestroyTransformDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -107,7 +107,7 @@ public class DestroyTransformAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class DestroyTransformCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [DestroyTransformAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DestroyTransformAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/EmptyUnityMessage.cs
+++ b/src/Microsoft.Unity.Analyzers/EmptyUnityMessage.cs
@@ -32,7 +32,7 @@ public class EmptyUnityMessageAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.EmptyUnityMessageDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -79,7 +79,7 @@ public class EmptyUnityMessageAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class EmptyUnityMessageCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [EmptyUnityMessageAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(EmptyUnityMessageAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
+++ b/src/Microsoft.Unity.Analyzers/GetComponentIncorrectType.cs
@@ -27,7 +27,7 @@ public class GetComponentIncorrectTypeAnalyzer : BaseGetComponentAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.GetComponentIncorrectTypeDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{

--- a/src/Microsoft.Unity.Analyzers/GetLocalPositionAndRotation.cs
+++ b/src/Microsoft.Unity.Analyzers/GetLocalPositionAndRotation.cs
@@ -35,7 +35,7 @@ public class GetLocalPositionAndRotationAnalyzer() : BasePositionAndRotationAnal
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.GetLocalPositionAndRotationDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -56,5 +56,5 @@ public class GetLocalPositionAndRotationCodeFix() : BasePositionAndRotationCodeF
 {
 	protected override string CodeFixTitle => Strings.GetLocalPositionAndRotationCodeFixTitle;
 
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [GetLocalPositionAndRotationAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(GetLocalPositionAndRotationAnalyzer.Rule.Id);
 }

--- a/src/Microsoft.Unity.Analyzers/GetPositionAndRotation.cs
+++ b/src/Microsoft.Unity.Analyzers/GetPositionAndRotation.cs
@@ -35,7 +35,7 @@ public class GetPositionAndRotationAnalyzer() : BasePositionAndRotationAnalyzer(
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.GetPositionAndRotationDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -56,5 +56,5 @@ public class GetPositionAndRotationCodeFix() : BasePositionAndRotationCodeFix(Ge
 {
 	protected override string CodeFixTitle => Strings.GetPositionAndRotationCodeFixTitle;
 
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [GetPositionAndRotationAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(GetPositionAndRotationAnalyzer.Rule.Id);
 }

--- a/src/Microsoft.Unity.Analyzers/ImplicitUsageAttributeSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/ImplicitUsageAttributeSuppressor.cs
@@ -28,7 +28,7 @@ public class ImplicitUsageAttributeSuppressor : BaseAttributeSuppressor
 		typeof(CreatePropertyAttribute)
 	];
 
-	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => [Rule];
+	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(Rule);
 
 	protected override SyntaxNode? GetSuppressibleNode(Diagnostic diagnostic, SuppressionAnalysisContext context)
 	{

--- a/src/Microsoft.Unity.Analyzers/ImproperMenuItemMethod.cs
+++ b/src/Microsoft.Unity.Analyzers/ImproperMenuItemMethod.cs
@@ -32,7 +32,7 @@ public class ImproperMenuItemMethodAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.ImproperMenuItemMethodDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -62,7 +62,7 @@ public class ImproperMenuItemMethodAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class ImproperMenuItemMethodCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [ImproperMenuItemMethodAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ImproperMenuItemMethodAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/ImproperMessageCase.cs
+++ b/src/Microsoft.Unity.Analyzers/ImproperMessageCase.cs
@@ -35,7 +35,7 @@ public class ImproperMessageCaseAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.ImproperMessageCaseDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -101,7 +101,7 @@ public class ImproperMessageCaseAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class ImproperMessageCaseCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [ImproperMessageCaseAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ImproperMessageCaseAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -139,7 +139,6 @@ public class ImproperMessageCaseCodeFix : CodeFixProvider
 		if (newName == null)
 			return solution;
 
-		var options = new SymbolRenameOptions { RenameFile = false, RenameInStrings = false, RenameInComments = false, RenameOverloads = false };
-		return await Renamer.RenameSymbolAsync(solution, methodSymbol, options, newName, cancellationToken);
+		return await Renamer.RenameSymbolAsync(solution, methodSymbol, newName, solution.Options, cancellationToken);
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/ImproperSerializeField.cs
+++ b/src/Microsoft.Unity.Analyzers/ImproperSerializeField.cs
@@ -28,7 +28,7 @@ public class ImproperSerializeFieldAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.ImproperSerializeFieldDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -90,7 +90,7 @@ public class ImproperSerializeFieldAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class ImproperSerializeFieldCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [ImproperSerializeFieldAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ImproperSerializeFieldAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/IndirectionMessage.cs
+++ b/src/Microsoft.Unity.Analyzers/IndirectionMessage.cs
@@ -32,7 +32,7 @@ public class IndirectionMessageAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.IndirectionMessageDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -69,7 +69,7 @@ public class IndirectionMessageAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class IndirectionMessageCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [IndirectionMessageAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(IndirectionMessageAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/InitializeOnLoadStaticCtor.cs
+++ b/src/Microsoft.Unity.Analyzers/InitializeOnLoadStaticCtor.cs
@@ -32,7 +32,7 @@ public class InitializeOnLoadStaticCtorAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.InitializeOnLoadStaticCtorDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -71,7 +71,7 @@ public class InitializeOnLoadStaticCtorAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class InitializeOnLoadStaticCtorCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [InitializeOnLoadStaticCtorAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(InitializeOnLoadStaticCtorAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/InputGetKey.cs
+++ b/src/Microsoft.Unity.Analyzers/InputGetKey.cs
@@ -36,7 +36,7 @@ public class InputGetKeyAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.InputGetKeyDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	private static readonly Lazy<Dictionary<string, KeyCode>> _lookup = new(BuildLookup);
 
@@ -132,7 +132,7 @@ public class InputGetKeyAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class InputGetKeyCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [InputGetKeyAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(InputGetKeyAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/LoadAttributeMethod.cs
+++ b/src/Microsoft.Unity.Analyzers/LoadAttributeMethod.cs
@@ -33,7 +33,7 @@ public class LoadAttributeMethodAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.LoadAttributeMethodDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -92,7 +92,7 @@ public class LoadAttributeMethodAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class LoadAttributeMethodCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [LoadAttributeMethodAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(LoadAttributeMethodAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/LoadAttributeMethodSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/LoadAttributeMethodSuppressor.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Unity.Analyzers
 				AnalyzeDiagnostic(diagnostic, context);
 		}
 
-		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => [Rule];
+		public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(Rule);
 
 		private static void AnalyzeDiagnostic(Diagnostic diagnostic, SuppressionAnalysisContext context)
 		{

--- a/src/Microsoft.Unity.Analyzers/MessageSignature.cs
+++ b/src/Microsoft.Unity.Analyzers/MessageSignature.cs
@@ -34,7 +34,7 @@ public class MessageSignatureAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.MessageSignatureDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -94,7 +94,7 @@ public class MessageSignatureAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class MessageSignatureCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [MessageSignatureAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(MessageSignatureAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -140,7 +140,7 @@ public class MessageSignatureCodeFix : CodeFixProvider
 		if (message == null)
 			return document;
 
-		var syntaxGenerator = document.Project.Services.GetService<SyntaxGenerator>();
+		var syntaxGenerator = document.Project.LanguageServices.GetService<SyntaxGenerator>();
 		if (syntaxGenerator == null)
 			return document;
 

--- a/src/Microsoft.Unity.Analyzers/MessageSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/MessageSuppressor.cs
@@ -41,7 +41,13 @@ public class MessageSuppressor : DiagnosticSuppressor
 		suppressedDiagnosticId: "CA1801",
 		justification: Strings.MessageSuppressorJustification);
 
-	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => [MethodRule, MethodCrefRule, MethodCodeQualityRule, ParameterRule, ParameterCodeQualityRule];
+	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(
+		MethodRule,
+		MethodCrefRule,
+		MethodCodeQualityRule,
+		ParameterRule,
+		ParameterCodeQualityRule
+	);
 
 	public override void ReportSuppressions(SuppressionAnalysisContext context)
 	{

--- a/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
+++ b/src/Microsoft.Unity.Analyzers/MethodInvocation.cs
@@ -35,7 +35,7 @@ public class MethodInvocationAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.MethodInvocationDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -110,7 +110,7 @@ public class MethodInvocationAnalyzer : DiagnosticAnalyzer
 
 public abstract class BaseMethodInvocationCodeFix(string title) : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [MethodInvocationAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(MethodInvocationAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/Microsoft.Unity.Analyzers.csproj
+++ b/src/Microsoft.Unity.Analyzers/Microsoft.Unity.Analyzers.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" VersionOverride="3.11.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" VersionOverride="3.11.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Unity.Analyzers/NonGenericGetComponent.cs
+++ b/src/Microsoft.Unity.Analyzers/NonGenericGetComponent.cs
@@ -34,7 +34,7 @@ public class NonGenericGetComponentAnalyzer : BaseGetComponentAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.NonGenericGetComponentDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -69,7 +69,7 @@ public class NonGenericGetComponentAnalyzer : BaseGetComponentAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class NonGenericGetComponentCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [NonGenericGetComponentAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(NonGenericGetComponentAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/NullableReferenceTypesSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/NullableReferenceTypesSuppressor.cs
@@ -22,7 +22,7 @@ public class NullableReferenceTypesSuppressor : DiagnosticSuppressor
 		suppressedDiagnosticId: "CS8618",
 		justification: Strings.NullableReferenceTypesSuppressorJustification);
 
-	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => [Rule];
+	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(Rule);
 
 	public override void ReportSuppressions(SuppressionAnalysisContext context)
 	{

--- a/src/Microsoft.Unity.Analyzers/PhysicsAllocMethodUsage.cs
+++ b/src/Microsoft.Unity.Analyzers/PhysicsAllocMethodUsage.cs
@@ -31,7 +31,7 @@ public class PhysicsAllocMethodUsageAnalyzer : MethodUsageAnalyzer<PhysicsAllocM
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.PhysicsAllocMethodUsageDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	protected override IEnumerable<MethodInfo> CollectMethods()
 	{

--- a/src/Microsoft.Unity.Analyzers/PropertyDrawerOnGUI.cs
+++ b/src/Microsoft.Unity.Analyzers/PropertyDrawerOnGUI.cs
@@ -32,7 +32,7 @@ public class PropertyDrawerOnGUIAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.PropertyDrawerOnGUIDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -64,7 +64,7 @@ public class PropertyDrawerOnGUIAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class PropertyDrawerOnGUICodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [PropertyDrawerOnGUIAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(PropertyDrawerOnGUIAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/ProtectedUnityMessage.cs
+++ b/src/Microsoft.Unity.Analyzers/ProtectedUnityMessage.cs
@@ -32,7 +32,7 @@ public class ProtectedUnityMessageAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.ProtectedUnityMessageDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -80,7 +80,7 @@ public class ProtectedUnityMessageAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class ProtectedUnityMessageCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [ProtectedUnityMessageAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ProtectedUnityMessageAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/Reflection.cs
+++ b/src/Microsoft.Unity.Analyzers/Reflection.cs
@@ -29,7 +29,7 @@ public class ReflectionAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.ReflectionDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{

--- a/src/Microsoft.Unity.Analyzers/RequireComponent.cs
+++ b/src/Microsoft.Unity.Analyzers/RequireComponent.cs
@@ -4,6 +4,7 @@
  *-------------------------------------------------------------------------------------------*/
 
 using System.Collections.Immutable;
+using System.Data;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,7 +36,7 @@ public class RequireComponentAnalyzer : BaseGetComponentAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.RequireComponentAnalyzerDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -113,7 +114,7 @@ public class RequireComponentAnalyzer : BaseGetComponentAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class RequireComponentCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [RequireComponentAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RequireComponentAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/SerializedFieldSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/SerializedFieldSuppressor.cs
@@ -35,12 +35,12 @@ public class SerializedFieldSuppressor : BaseAttributeSuppressor
 		suppressedDiagnosticId: "CS0649",
 		justification: Strings.NeverAssignedSerializedFieldSuppressorJustification);
 
-	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => [
+	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(
 		ReadonlyRule,
 		UnusedRule,
 		UnusedCodeQualityRule,
 		NeverAssignedRule
-	];
+	);
 
 	protected override Type[] SuppressableAttributeTypes =>
 	[

--- a/src/Microsoft.Unity.Analyzers/SetLocalPositionAndRotation.cs
+++ b/src/Microsoft.Unity.Analyzers/SetLocalPositionAndRotation.cs
@@ -34,7 +34,7 @@ public class SetLocalPositionAndRotationAnalyzer() : BasePositionAndRotationAnal
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.SetLocalPositionAndRotationDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	protected override void OnPatternFound(SyntaxNodeAnalysisContext context, StatementSyntax statement)
 	{
@@ -47,5 +47,5 @@ public class SetLocalPositionAndRotationCodeFix() : BasePositionAndRotationCodeF
 {
 	protected override string CodeFixTitle => Strings.SetLocalPositionAndRotationCodeFixTitle;
 
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [SetLocalPositionAndRotationAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(SetLocalPositionAndRotationAnalyzer.Rule.Id);
 }

--- a/src/Microsoft.Unity.Analyzers/SetPixelsMethodUsage.cs
+++ b/src/Microsoft.Unity.Analyzers/SetPixelsMethodUsage.cs
@@ -30,7 +30,7 @@ public class SetPixelsMethodUsageAnalyzer : MethodUsageAnalyzer<SetPixelsMethodU
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.SetPixelsMethodUsageDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	protected override IEnumerable<MethodInfo> CollectMethods()
 	{

--- a/src/Microsoft.Unity.Analyzers/SetPositionAndRotation.cs
+++ b/src/Microsoft.Unity.Analyzers/SetPositionAndRotation.cs
@@ -34,7 +34,7 @@ public class SetPositionAndRotationAnalyzer() : BasePositionAndRotationAnalyzer(
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.SetPositionAndRotationDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	protected override void OnPatternFound(SyntaxNodeAnalysisContext context, StatementSyntax statement)
 	{
@@ -47,5 +47,5 @@ public class SetPositionAndRotationCodeFix() : BasePositionAndRotationCodeFix(Se
 {
 	protected override string CodeFixTitle => Strings.SetPositionAndRotationCodeFixTitle;
 
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [SetPositionAndRotationAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(SetPositionAndRotationAnalyzer.Rule.Id);
 }

--- a/src/Microsoft.Unity.Analyzers/TagComparison.cs
+++ b/src/Microsoft.Unity.Analyzers/TagComparison.cs
@@ -33,7 +33,7 @@ public class TagComparisonAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.TagComparisonDiagnosticDescription);
 
-	public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public sealed override void Initialize(AnalysisContext context)
 	{
@@ -129,7 +129,7 @@ public class TagComparisonAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class TagComparisonCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [TagComparisonAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(TagComparisonAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/ThrowExpressionSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/ThrowExpressionSuppressor.cs
@@ -28,7 +28,7 @@ public class ThrowExpressionSuppressor : DiagnosticSuppressor
 		}
 	}
 
-	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => [Rule];
+	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(Rule);
 
 	private static void AnalyzeDiagnostic(Diagnostic diagnostic, SuppressionAnalysisContext context)
 	{

--- a/src/Microsoft.Unity.Analyzers/TryGetComponent.cs
+++ b/src/Microsoft.Unity.Analyzers/TryGetComponent.cs
@@ -34,7 +34,7 @@ public class TryGetComponentAnalyzer : BaseGetComponentAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.TryGetComponentDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -109,7 +109,7 @@ internal class TryGetComponentContext(string targetIdentifier, IfStatementSyntax
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class TryGetComponentCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [TryGetComponentAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(TryGetComponentAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/UnityObjectNullHandling.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityObjectNullHandling.cs
@@ -65,8 +65,12 @@ public class UnityObjectNullHandlingAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(IsPatternRuleId),
 		description: Strings.UnityObjectIsPatternDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [NullCoalescingRule, NullPropagationRule, CoalescingAssignmentRule, IsPatternRule
-];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+		NullCoalescingRule,
+		NullPropagationRule,
+		CoalescingAssignmentRule,
+		IsPatternRule
+	);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -128,14 +132,12 @@ public class UnityObjectNullHandlingAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class UnityObjectNullHandlingCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds =>
-	[
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
 		UnityObjectNullHandlingAnalyzer.NullCoalescingRule.Id,
 		UnityObjectNullHandlingAnalyzer.NullPropagationRule.Id,
 		UnityObjectNullHandlingAnalyzer.CoalescingAssignmentRule.Id,
 		UnityObjectNullHandlingAnalyzer.IsPatternRule.Id
-,
-	];
+	);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -292,7 +294,13 @@ public class UnityObjectNullHandlingSuppressor : DiagnosticSuppressor
 		suppressedDiagnosticId: "IDE0270",
 		justification: Strings.UnityObjectIfNullCoalescingSuppressorJustification);
 
-	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => [NullCoalescingRule, NullPropagationRule, CoalescingAssignmentRule, UseIsNullRule, IfNullCoalescingRule];
+	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(
+		NullCoalescingRule,
+		NullPropagationRule,
+		CoalescingAssignmentRule,
+		UseIsNullRule,
+		IfNullCoalescingRule
+	);
 
 	public override void ReportSuppressions(SuppressionAnalysisContext context)
 	{

--- a/src/Microsoft.Unity.Analyzers/UnusedCoroutineReturnValue.cs
+++ b/src/Microsoft.Unity.Analyzers/UnusedCoroutineReturnValue.cs
@@ -28,7 +28,7 @@ public class UnusedCoroutineReturnValueAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.UnusedCoroutineReturnValueDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -74,7 +74,7 @@ public class UnusedCoroutineReturnValueAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class UnusedCoroutineReturnValueCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [UnusedCoroutineReturnValueAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(UnusedCoroutineReturnValueAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Microsoft.Unity.Analyzers/UnusedMethodSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/UnusedMethodSuppressor.cs
@@ -28,7 +28,7 @@ public class UnusedMethodSuppressor : DiagnosticSuppressor
 		}
 	}
 
-	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => [Rule];
+	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(Rule);
 
 	private static void AnalyzeDiagnostic(Diagnostic diagnostic, SuppressionAnalysisContext context)
 	{

--- a/src/Microsoft.Unity.Analyzers/UpdateDeltaTime.cs
+++ b/src/Microsoft.Unity.Analyzers/UpdateDeltaTime.cs
@@ -45,7 +45,10 @@ public class UpdateDeltaTimeAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(FixedUpdateId),
 		description: Strings.FixedUpdateWithoutDeltaTimeDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [UpdateRule, FixedUpdateRule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+		UpdateRule,
+		FixedUpdateRule
+	);
 
 	public override void Initialize(AnalysisContext context)
 	{
@@ -107,7 +110,10 @@ public class UpdateDeltaTimeCodeFix : CodeFixProvider
 {
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [UpdateDeltaTimeAnalyzer.UpdateId, UpdateDeltaTimeAnalyzer.FixedUpdateId];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
+		UpdateDeltaTimeAnalyzer.UpdateId,
+		UpdateDeltaTimeAnalyzer.FixedUpdateId
+	);
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/Microsoft.Unity.Analyzers/Vector2Conversion.cs
+++ b/src/Microsoft.Unity.Analyzers/Vector2Conversion.cs
@@ -30,7 +30,7 @@ public class Vector2ConversionAnalyzer : BaseVectorConversionAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.Vector3ConversionDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	protected override Type FromType => typeof(Vector2);
 	protected override Type ToType => typeof(Vector3);
@@ -61,7 +61,7 @@ public class Vector2ConversionAnalyzer : BaseVectorConversionAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class Vector2ConversionCodeFix : BaseVectorConversionCodeFix
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [Vector2ConversionAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Vector2ConversionAnalyzer.Rule.Id);
 
 	public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/Microsoft.Unity.Analyzers/Vector3Conversion.cs
+++ b/src/Microsoft.Unity.Analyzers/Vector3Conversion.cs
@@ -30,7 +30,7 @@ public class Vector3ConversionAnalyzer : BaseVectorConversionAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.Vector3ConversionDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	protected override Type FromType => typeof(Vector3);
 	protected override Type ToType => typeof(Vector2);
@@ -52,7 +52,7 @@ public class Vector3ConversionAnalyzer : BaseVectorConversionAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class Vector3ConversionCodeFix : BaseVectorConversionCodeFix
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [Vector3ConversionAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Vector3ConversionAnalyzer.Rule.Id);
 
 	protected override Type CastType => typeof(Vector2);
 

--- a/src/Microsoft.Unity.Analyzers/VectorMath.cs
+++ b/src/Microsoft.Unity.Analyzers/VectorMath.cs
@@ -36,7 +36,7 @@ public class VectorMathAnalyzer : DiagnosticAnalyzer
 		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
 		description: Strings.VectorMathDiagnosticDescription);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
 	internal Type[] SupportedTypes =
 	[
@@ -158,7 +158,7 @@ public class VectorMathAnalyzer : DiagnosticAnalyzer
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class VectorMathCodeFix : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds => [VectorMathAnalyzer.Rule.Id];
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(VectorMathAnalyzer.Rule.Id);
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 


### PR DESCRIPTION
Rollback Roslyn unification

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [x] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
- For a long time we kept the main analyzer project and the test project with distinct Roslyn versions.
- We tried to unify recently (mainly because of dependabot) but this is impacting users of the nuget package.
- So rollback the unification, and change the way we override versions. `Directory.Package.props` will continue to have the latest versions, and the anlayzer project is now using a `VersionOverride`.

cc @AlfishSoftware as discussed in https://github.com/microsoft/Microsoft.Unity.Analyzers/pull/377#issuecomment-3104502017
