### PR TITLE
Add support for UniTask

### DIFF
--- a/src/Microsoft.Unity.Analyzers/UnityStubs.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityStubs.cs
@@ -813,4 +813,11 @@ namespace Sirenix.Serialization
 	class OdinSerializeAttribute : Attribute { }
 }
 
+namespace Cysharp.Threading.Tasks
+{
+	class UniTask { }
+	class UniTask<T> { }
+	class UniTaskVoid { }
+}
+
 #pragma warning enable


### PR DESCRIPTION
Fixes #410 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [X] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Add support for `UniTask` for Unity messages, similarly to what we've done for the built-in `Awaitable`.

`UniTask` users where forced to suppress `UNT0006`:
https://github.com/YARC-Official/YARG/blob/0050bf60b7f87a4fb10faf0d96be49e9549b40d8/Assets/Script/Gameplay/BackgroundManager.cs#L46

Note: we have to review/sync IDE-side message detection as well.

