### PR TITLE
`CodeStyleSuppressor` now suppresses `IDE1006` for `ScriptableObject`s too

### DIFF
--- a/src/Microsoft.Unity.Analyzers/CodeStyleSuppressor.cs
+++ b/src/Microsoft.Unity.Analyzers/CodeStyleSuppressor.cs
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *-------------------------------------------------------------------------------------------*/
 
+using System;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -18,6 +20,11 @@ public class CodeStyleSuppressor : DiagnosticSuppressor
 		id: "USP0023",
 		suppressedDiagnosticId: "IDE1006",
 		justification: Strings.CodeStyleSuppressorJustification);
+
+	public static readonly ImmutableArray<Type> UnityMessageBaseTypes = ImmutableArray.Create(
+		typeof(UnityEngine.MonoBehaviour),
+		typeof(UnityEngine.ScriptableObject)
+	);
 
 	public override void ReportSuppressions(SuppressionAnalysisContext context)
 	{
@@ -44,7 +51,7 @@ public class CodeStyleSuppressor : DiagnosticSuppressor
 			return;
 
 		var typeSymbol = methodSymbol.ContainingType;
-		if (!typeSymbol.Extends(typeof(UnityEngine.MonoBehaviour)))
+		if (!UnityMessageBaseTypes.Any(typeSymbol.Extends))
 			return;
 
 		var scriptInfo = new ScriptInfo(methodSymbol.ContainingType);


### PR DESCRIPTION
~~Fixes #~~ This is basically just a fuller fix of #404, expanding on PR #408

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](/CONTRIBUTING.md) ;
- [ ] ~~There is an approved issue describing the change when contributing a new analyzer or suppressor~~ No, but this is basically just a follow-up to #404 ;
- [x] I have added tests that prove my fix is effective or that my feature works **(I expanded on those in #408)** ;
- [x] I have added necessary documentation (if appropriate) **(Didn't seem like any of the `USP0023` docs needed updating)** ;

#### Short description of what this resolves:

#408 suppresses code style messages about naming for `MonoBehaviour`-derived types, but not for types derived from other Unity types. The only other type I'm aware of with Unity messages is `ScriptableObject`. However, if more base types with Unity messages must have code style messages suppressed then they can simply be added to the new `CodeStyleSuppressor.UnityMessageBaseTypes` array.

#### Changes proposed in this pull request:
- N/A