### PR TITLE
Fixes UNT0008

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingTests.cs
@@ -306,6 +306,87 @@ class Camera : MonoBehaviour
 	}
 
 	[Fact]
+	public async Task FixNullPropagationInvocationStatementTrivia()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Rotate : MonoBehaviour { }
+
+class Camera : MonoBehaviour
+{
+    void Update()
+    {
+        // before
+        gameObject?.AddComponent(typeof(Rotate)); // trailing
+        // after
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic(UnityObjectNullHandlingAnalyzer.NullPropagationRule)
+			.WithLocation(11, 9);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+
+class Rotate : MonoBehaviour { }
+
+class Camera : MonoBehaviour
+{
+    void Update()
+    {
+        // before
+        if (gameObject != null)
+            gameObject.AddComponent(typeof(Rotate)); // trailing
+        // after
+    }
+}
+";
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task FixNullPropagationInvocationExpressionTrivia()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Rotate : MonoBehaviour { }
+
+class Camera : MonoBehaviour
+{
+    Component NP()
+    {
+        return /* inner */ gameObject?.AddComponent(typeof(Rotate));
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic(UnityObjectNullHandlingAnalyzer.NullPropagationRule)
+			.WithLocation(10, 28);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+
+class Rotate : MonoBehaviour { }
+
+class Camera : MonoBehaviour
+{
+    Component NP()
+    {
+        return /* inner */ gameObject != null ? gameObject.AddComponent(typeof(Rotate)) : null;
+    }
+}
+";
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
 	public async Task FixNullPropagationInvocationExpression()
 	{
 		const string test = @"

--- a/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityObjectNullHandlingTests.cs
@@ -263,6 +263,224 @@ class Camera : MonoBehaviour
 		await VerifyCSharpFixAsync(test, test);
 	}
 
+	[Fact]
+	public async Task FixNullPropagationInvocationStatement()
+	{
+		// See https://github.com/microsoft/Microsoft.Unity.Analyzers/issues/468
+		// `obj?.Method(args);` used as a statement is not a member binding so the codefix
+		// previously returned the document unchanged, leaving the VS lightbulb as a no-op.
+		const string test = @"
+using UnityEngine;
+
+class Rotate : MonoBehaviour { }
+
+class Camera : MonoBehaviour
+{
+    void Update()
+    {
+        gameObject?.AddComponent(typeof(Rotate));
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic(UnityObjectNullHandlingAnalyzer.NullPropagationRule)
+			.WithLocation(10, 9);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+
+class Rotate : MonoBehaviour { }
+
+class Camera : MonoBehaviour
+{
+    void Update()
+    {
+        if (gameObject != null)
+            gameObject.AddComponent(typeof(Rotate));
+    }
+}
+";
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task FixNullPropagationInvocationExpression()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Rotate : MonoBehaviour { }
+
+class Camera : MonoBehaviour
+{
+    Component NP()
+    {
+        return gameObject?.AddComponent(typeof(Rotate));
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic(UnityObjectNullHandlingAnalyzer.NullPropagationRule)
+			.WithLocation(10, 16);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+
+class Rotate : MonoBehaviour { }
+
+class Camera : MonoBehaviour
+{
+    Component NP()
+    {
+        return gameObject != null ? gameObject.AddComponent(typeof(Rotate)) : null;
+    }
+}
+";
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task FixNullPropagationInvocationChain()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    GameObject NP()
+    {
+        return transform?.GetChild(0).gameObject;
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic(UnityObjectNullHandlingAnalyzer.NullPropagationRule)
+			.WithLocation(8, 16);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    GameObject NP()
+    {
+        return transform != null ? transform.GetChild(0).gameObject : null;
+    }
+}
+";
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task CantFixNullPropagationValueTypeResult()
+	{
+		// `transform?.gameObject.activeInHierarchy` yields `bool?` (Nullable<bool>). A naive ternary
+		// rewrite would have branches `bool` and `null` which cannot be unified - we must skip rather
+		// than emit non-compiling code.
+		const string test = @"
+using UnityEngine;
+
+class Camera : MonoBehaviour
+{
+    bool NP()
+    {
+        return transform?.gameObject.activeInHierarchy ?? false;
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic(UnityObjectNullHandlingAnalyzer.NullPropagationRule)
+			.WithLocation(8, 16);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		// we cannot safely fix without introducing a cast
+		await VerifyCSharpFixAsync(test, test);
+	}
+
+	[Fact]
+	public async Task FixNullPropagationDanglingElse()
+	{
+		// The original `obj?.Foo();` is the `then` branch of an outer if-else; without block-wrapping
+		// the rewrite would bind the outer `else` to the generated inner `if`.
+		const string test = @"
+using UnityEngine;
+
+class Rotate : MonoBehaviour { }
+
+class Camera : MonoBehaviour
+{
+    void Update()
+    {
+        if (enabled)
+            gameObject?.AddComponent(typeof(Rotate));
+        else
+            Debug.Log(""no"");
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic(UnityObjectNullHandlingAnalyzer.NullPropagationRule)
+			.WithLocation(11, 13);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+
+class Rotate : MonoBehaviour { }
+
+class Camera : MonoBehaviour
+{
+    void Update()
+    {
+        if (enabled)
+        {
+            if (gameObject != null)
+                gameObject.AddComponent(typeof(Rotate));
+        }
+        else
+            Debug.Log(""no"");
+    }
+}
+";
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task CantFixNullPropagationNestedReceiverSideEffect()
+	{
+		// `GetComponent<Camera>().gameObject` is syntactically a member access, but the receiver is
+		// an invocation. Strengthened HasSideEffect must reject this so we don't duplicate the call.
+		const string test = @"
+using UnityEngine;
+
+class Rotate : MonoBehaviour { }
+
+class Camera : MonoBehaviour
+{
+    void Update()
+    {
+        GetComponent<Camera>().gameObject?.AddComponent(typeof(Rotate));
+    }
+}
+";
+
+		var diagnostic = ExpectDiagnostic(UnityObjectNullHandlingAnalyzer.NullPropagationRule)
+			.WithLocation(10, 9);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		// we cannot fix because the receiver (.gameObject) hangs off an invocation with side effects
+		await VerifyCSharpFixAsync(test, test);
+	}
+
 
 	[Fact]
 	public async Task FixCoalescingAssignment()

--- a/src/Microsoft.Unity.Analyzers/UnityObjectNullHandling.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityObjectNullHandling.cs
@@ -299,7 +299,8 @@ public class UnityObjectNullHandlingCodeFix : CodeFixProvider
 		var conditional = SyntaxFactory.ConditionalExpression(
 			condition: condition,
 			whenTrue: rewrittenWhenNotNull.WithoutTrivia(),
-			whenFalse: SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
+			whenFalse: SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression))
+			.WithTriviaFrom(access);
 
 		return await ReplaceWithAsync(document, access, conditional, cancellationToken);
 	}
@@ -323,7 +324,7 @@ public class UnityObjectNullHandlingCodeFix : CodeFixProvider
 	private static ExpressionSyntax? RewriteWhenNotNull(ConditionalAccessExpressionSyntax access)
 	{
 		var binding = FindLeftmostBinding(access.WhenNotNull);
-		ExpressionSyntax replacement = binding switch
+		ExpressionSyntax? replacement = binding switch
 		{
 			MemberBindingExpressionSyntax mbes => SyntaxFactory.MemberAccessExpression(
 				SyntaxKind.SimpleMemberAccessExpression,
@@ -332,23 +333,23 @@ public class UnityObjectNullHandlingCodeFix : CodeFixProvider
 			ElementBindingExpressionSyntax ebes => SyntaxFactory.ElementAccessExpression(
 				access.Expression.WithoutTrivia(),
 				ebes.ArgumentList),
-			_ => null!,
+			_ => null,
 		};
 
-		if (replacement == null!)
+		if (replacement is null || binding is null)
 			return null;
 
 		if (ReferenceEquals(binding, access.WhenNotNull))
 			return replacement;
 
-		return access.WhenNotNull.ReplaceNode(binding!, replacement);
+		return access.WhenNotNull.ReplaceNode(binding, replacement);
 	}
 
 	private static ExpressionSyntax? FindLeftmostBinding(ExpressionSyntax expression)
 	{
 		// Descend into the chain until we reach the `?.`-bound prefix (MemberBindingExpression / ElementBindingExpression).
-		ExpressionSyntax? current = expression;
-		while (current != null)
+		var current = expression;
+		while (true)
 		{
 			switch (current)
 			{
@@ -371,7 +372,6 @@ public class UnityObjectNullHandlingCodeFix : CodeFixProvider
 					return null;
 			}
 		}
-		return null;
 	}
 
 	private static Task<Document> ReplacePatternExpressionAsync(Document document, IsPatternExpressionSyntax pattern, CancellationToken cancellationToken)

--- a/src/Microsoft.Unity.Analyzers/UnityObjectNullHandling.cs
+++ b/src/Microsoft.Unity.Analyzers/UnityObjectNullHandling.cs
@@ -166,6 +166,20 @@ public class UnityObjectNullHandlingCodeFix : CodeFixProvider
 				if (HasSideEffect(caes.Expression))
 					return;
 
+				if (FindLeftmostBinding(caes.WhenNotNull) == null)
+					return;
+
+				// For the expression form we emit `obj != null ? <rewritten> : null`. If the original
+				// conditional access yields a value type (i.e. Nullable<T>), the ternary's branches
+				// (T and null) cannot be unified without an explicit cast - skip rather than emit
+				// non-compiling code. Statement form (handled in the rewrite) is unaffected.
+				if (GetEnclosingExpressionStatement(caes) == null)
+				{
+					var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+					if (semanticModel != null && IsValueTypeOrNullable(semanticModel.GetTypeInfo(caes).Type))
+						return;
+				}
+
 				action = CodeAction.Create(
 					Strings.UnityObjectNullPropagationCodeFixTitle,
 					ct => ReplaceNullPropagationAsync(context.Document, caes, ct),
@@ -205,11 +219,20 @@ public class UnityObjectNullHandlingCodeFix : CodeFixProvider
 	// We could potentially rewrite by introducing a variable
 	private static bool HasSideEffect(ExpressionSyntax expression)
 	{
-		return expression.Kind() switch
+		return expression switch
 		{
-			SyntaxKind.SimpleMemberAccessExpression or SyntaxKind.PointerMemberAccessExpression or SyntaxKind.IdentifierName => false,
+			IdentifierNameSyntax => false,
+			ThisExpressionSyntax => false,
+			MemberAccessExpressionSyntax { RawKind: (int)SyntaxKind.SimpleMemberAccessExpression or (int)SyntaxKind.PointerMemberAccessExpression } mae => HasSideEffect(mae.Expression),
+			ParenthesizedExpressionSyntax pes => HasSideEffect(pes.Expression),
 			_ => true,
 		};
+	}
+
+	private static bool IsValueTypeOrNullable(ITypeSymbol? type)
+	{
+		// Nullable<T> is itself a value type - this catches both T and T?.
+		return type is { IsValueType: true };
 	}
 
 	private static async Task<Document> ReplaceWithAsync(Document document, SyntaxNode source, SyntaxNode replacement, CancellationToken cancellationToken)
@@ -244,16 +267,111 @@ public class UnityObjectNullHandlingCodeFix : CodeFixProvider
 
 	private static async Task<Document> ReplaceNullPropagationAsync(Document document, ConditionalAccessExpressionSyntax access, CancellationToken cancellationToken)
 	{
-		// obj?.member -> obj != null ? obj.member : null
-		if (access.WhenNotNull is not MemberBindingExpressionSyntax mbes)
+		// obj?.member         -> obj != null ? obj.member : null
+		// obj?.member(args)   -> obj != null ? obj.member(args) : null
+		// obj?.member(args);  -> if (obj != null) obj.member(args);   (statement form, avoids CS0201)
+		var rewrittenWhenNotNull = RewriteWhenNotNull(access);
+		if (rewrittenWhenNotNull == null)
 			return document;
 
+		var condition = SyntaxFactory.BinaryExpression(
+			SyntaxKind.NotEqualsExpression,
+			access.Expression.WithoutTrivia(),
+			SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
+
+		// When the conditional access is the entire expression of an expression statement,
+		// a ternary cannot be used at statement level (CS0201). Use an `if` statement instead.
+		// Walk through any parenthesized wrappers to find the enclosing statement.
+		var enclosingStatement = GetEnclosingExpressionStatement(access);
+		if (enclosingStatement != null)
+		{
+			StatementSyntax ifStatement = SyntaxFactory.IfStatement(
+				condition,
+				SyntaxFactory.ExpressionStatement(rewrittenWhenNotNull.WithoutTrivia()));
+
+			// Wrap with a block when needed to avoid dangling-else ambiguity (e.g. parent if/else).
+			if (RequiresBlockWrap(enclosingStatement))
+				ifStatement = SyntaxFactory.Block(ifStatement);
+
+			return await ReplaceWithAsync(document, enclosingStatement, ifStatement.WithTriviaFrom(enclosingStatement), cancellationToken);
+		}
+
 		var conditional = SyntaxFactory.ConditionalExpression(
-			condition: SyntaxFactory.BinaryExpression(SyntaxKind.NotEqualsExpression, access.Expression, SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)),
-			whenTrue: SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, access.Expression, mbes.Name),
+			condition: condition,
+			whenTrue: rewrittenWhenNotNull.WithoutTrivia(),
 			whenFalse: SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
 
 		return await ReplaceWithAsync(document, access, conditional, cancellationToken);
+	}
+
+	private static ExpressionStatementSyntax? GetEnclosingExpressionStatement(ConditionalAccessExpressionSyntax access)
+	{
+		SyntaxNode? current = access;
+		while (current?.Parent is ParenthesizedExpressionSyntax pes)
+			current = pes;
+
+		return current?.Parent as ExpressionStatementSyntax;
+	}
+
+	private static bool RequiresBlockWrap(StatementSyntax statement)
+	{
+		// Avoid dangling-else: `if (cond) obj?.Foo(); else Bar();` must not become
+		// `if (cond) if (obj != null) obj.Foo(); else Bar();` (else would bind to inner if).
+		return statement.Parent is IfStatementSyntax { Else: not null } parentIf && parentIf.Statement == statement;
+	}
+
+	private static ExpressionSyntax? RewriteWhenNotNull(ConditionalAccessExpressionSyntax access)
+	{
+		var binding = FindLeftmostBinding(access.WhenNotNull);
+		ExpressionSyntax replacement = binding switch
+		{
+			MemberBindingExpressionSyntax mbes => SyntaxFactory.MemberAccessExpression(
+				SyntaxKind.SimpleMemberAccessExpression,
+				access.Expression.WithoutTrivia(),
+				mbes.Name),
+			ElementBindingExpressionSyntax ebes => SyntaxFactory.ElementAccessExpression(
+				access.Expression.WithoutTrivia(),
+				ebes.ArgumentList),
+			_ => null!,
+		};
+
+		if (replacement == null!)
+			return null;
+
+		if (ReferenceEquals(binding, access.WhenNotNull))
+			return replacement;
+
+		return access.WhenNotNull.ReplaceNode(binding!, replacement);
+	}
+
+	private static ExpressionSyntax? FindLeftmostBinding(ExpressionSyntax expression)
+	{
+		// Descend into the chain until we reach the `?.`-bound prefix (MemberBindingExpression / ElementBindingExpression).
+		ExpressionSyntax? current = expression;
+		while (current != null)
+		{
+			switch (current)
+			{
+				case MemberBindingExpressionSyntax:
+				case ElementBindingExpressionSyntax:
+					return current;
+				case MemberAccessExpressionSyntax mae:
+					current = mae.Expression;
+					break;
+				case InvocationExpressionSyntax ie:
+					current = ie.Expression;
+					break;
+				case ElementAccessExpressionSyntax eae:
+					current = eae.Expression;
+					break;
+				case ConditionalAccessExpressionSyntax cae:
+					current = cae.Expression;
+					break;
+				default:
+					return null;
+			}
+		}
+		return null;
 	}
 
 	private static Task<Document> ReplacePatternExpressionAsync(Document document, IsPatternExpressionSyntax pattern, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes #468

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](../CONTRIBUTING.md) ;
- [x] There is an approved issue describing the change when contributing a new analyzer or suppressor ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
ReplaceNullPropagationAsync only handled obj?.member (where WhenNotNull is directly a MemberBindingExpressionSyntax) and silently returned the unchanged document for everything else — invocations, chains, indexers — causing the VS lightbulb to be a no-op.