### PR TITLE
UNT0039: do not report GetComponent inside editor-only messages

### DIFF
--- a/doc/UNT0039.md
+++ b/doc/UNT0039.md
@@ -38,3 +38,21 @@ public class PlayerScript : MonoBehaviour
 ```
 
 A code fix is offered for this diagnostic to automatically apply this change.
+
+## Examples of patterns that are not flagged by this analyzer
+
+`GetComponent` calls inside editor-only messages (`Reset`, `OnValidate`) are not flagged: those messages are typically used to populate serialized fields with default references that a user can override, so the component is not a hard requirement.
+
+```csharp
+using UnityEngine;
+
+public class PlayerScript : MonoBehaviour
+{
+    public Rigidbody rb;
+
+    void Reset()
+    {
+        rb = GetComponent<Rigidbody>();
+    }
+}
+```

--- a/src/Microsoft.Unity.Analyzers.Tests/RequireComponentTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/RequireComponentTests.cs
@@ -327,4 +327,64 @@ public class PlayerScript : MonoBehaviour
 
 		await VerifyCSharpDiagnosticAsync(test);
 	}
+
+	[Fact]
+	public async Task GetComponentInResetMessage()
+	{
+		const string test = @"
+using UnityEngine;
+
+public class PlayerScript : MonoBehaviour
+{
+    public Rigidbody rb;
+
+    void Reset()
+    {
+        rb = GetComponent<Rigidbody>();
+    }
+}";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task GetComponentInOnValidateMessage()
+	{
+		const string test = @"
+using UnityEngine;
+
+public class PlayerScript : MonoBehaviour
+{
+    public Rigidbody rb;
+
+    void OnValidate()
+    {
+        rb = GetComponent<Rigidbody>();
+    }
+}";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task GetComponentInResetOverload()
+	{
+		const string test = @"
+using UnityEngine;
+
+public class PlayerScript : MonoBehaviour
+{
+    public Rigidbody rb;
+
+    void Reset(int value)
+    {
+        rb = GetComponent<Rigidbody>();
+    }
+}";
+
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(10, 14);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+	}
 }

--- a/src/Microsoft.Unity.Analyzers/GameObjectIsStatic.cs
+++ b/src/Microsoft.Unity.Analyzers/GameObjectIsStatic.cs
@@ -4,7 +4,6 @@
  *-------------------------------------------------------------------------------------------*/
 
 using System.Collections.Immutable;
-using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -31,7 +30,6 @@ public class GameObjectIsStaticAnalyzer : DiagnosticAnalyzer
 
 	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-	private static readonly string[] EditorOnlyMessages = ["OnValidate", "Reset"];
 	private static readonly Regex EditorFolderRegex = new(@"[/\\]Assets[/\\].*[/\\]Editor[/\\]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
 	public override void Initialize(AnalysisContext context)
@@ -59,7 +57,7 @@ public class GameObjectIsStaticAnalyzer : DiagnosticAnalyzer
 		if (DirectiveHelper.IsInsideDirective(memberAccess, "UNITY_EDITOR"))
 			return;
 
-		if (IsInsideEditorOnlyMessage(memberAccess, context.SemanticModel))
+		if (memberAccess.IsInsideEditorOnlyMessage(context.SemanticModel))
 			return;
 
 		if (IsInsideEditorFolder(context))
@@ -72,22 +70,5 @@ public class GameObjectIsStaticAnalyzer : DiagnosticAnalyzer
 	{
 		var filePath = context.Node.SyntaxTree.FilePath;
 		return !string.IsNullOrWhiteSpace(filePath) && EditorFolderRegex.IsMatch(filePath);
-	}
-
-	private static bool IsInsideEditorOnlyMessage(SyntaxNode node, SemanticModel semanticModel)
-	{
-		var methodSyntax = node.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
-		if (methodSyntax == null)
-			return false;
-
-		var methodSymbol = semanticModel.GetDeclaredSymbol(methodSyntax);
-		if (methodSymbol == null)
-			return false;
-
-		var scriptInfo = new ScriptInfo(methodSymbol.ContainingType);
-		if (!scriptInfo.HasMessages)
-			return false;
-
-		return EditorOnlyMessages.Contains(methodSymbol.Name) && scriptInfo.IsMessage(methodSymbol);
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/RequireComponent.cs
+++ b/src/Microsoft.Unity.Analyzers/RequireComponent.cs
@@ -65,9 +65,14 @@ public class RequireComponentAnalyzer : BaseGetComponentAnalyzer
 		if (!containerType.Extends(typeof(MonoBehaviour)))
 			return;
 
+		// GetComponent inside editor-only messages is typically used to populate
+		// serialized fields with overridable defaults, so the component is not a hard requirement
+		if (invocation.IsInsideEditorOnlyMessage(model))
+			return;
+
 		var componentType = method.TypeArguments.First(); // Checked by IsGenericGetComponent
 		if (componentType.TypeKind == TypeKind.TypeParameter)
-        	return;
+			return;
 
 		if (IsTypeAlreadyRequired(containerType, componentType))
 			return;

--- a/src/Microsoft.Unity.Analyzers/SyntaxNodeExtensions.cs
+++ b/src/Microsoft.Unity.Analyzers/SyntaxNodeExtensions.cs
@@ -3,12 +3,37 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *-------------------------------------------------------------------------------------------*/
 
+using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.Unity.Analyzers;
 
 internal static class SyntaxNodeExtensions
 {
+	private static readonly string[] EditorOnlyMessages = ["OnValidate", "Reset"];
+
+	extension(SyntaxNode node)
+	{
+		public bool IsInsideEditorOnlyMessage(SemanticModel semanticModel)
+		{
+			var methodSyntax = node.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+			if (methodSyntax == null)
+				return false;
+
+			var methodSymbol = semanticModel.GetDeclaredSymbol(methodSyntax);
+			if (methodSymbol == null)
+				return false;
+
+			var scriptInfo = new ScriptInfo(methodSymbol.ContainingType);
+			if (!scriptInfo.HasMessages)
+				return false;
+
+			return EditorOnlyMessages.Contains(methodSymbol.Name) && scriptInfo.IsMessage(methodSymbol);
+		}
+	}
+
 	extension(SyntaxNode first)
 	{
 		public SyntaxTriviaList MergeLeadingTriviaWith(SyntaxNode second)


### PR DESCRIPTION
Fixes #453

## Why

UNT0039 suggests `[RequireComponent]` whenever a MonoBehaviour self-invokes `GetComponent<T>()`. A common editor pattern is to populate a serialized field with a default reference inside `Reset()`, letting users override it in the inspector. In that context the component is not a hard requirement, so suggesting `[RequireComponent]` is misleading.

## What

- UNT0039 now skips `GetComponent` invocations made inside editor-only Unity messages (`Reset`, `OnValidate`).
- The editor-only message detection previously private to `GameObjectIsStaticAnalyzer` (UNT0040) is moved to `SyntaxNodeExtensions` and shared by both analyzers; no behavior change for UNT0040.
- Tests: no diagnostic in `Reset` / `OnValidate`; a `Reset(int)` overload (not a Unity message) still reports. Doc page updated with a non-flagged example.

## Notes

The issue mentions `Reset`; `OnValidate` is included because it is the same editor-only prefill context and the existing editor-only message pair already models it. Happy to narrow this to `Reset` only if preferred.