### PR TITLE
Tests: skip incomplete Unity installations when probing for an editor

### DIFF
--- a/src/Microsoft.Unity.Analyzers.Tests/UnityPath.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/UnityPath.cs
@@ -117,7 +117,14 @@ internal static class UnityPath
 
 	private static void RegisterUnityInstallation(string path)
 	{
-		if (!string.IsNullOrEmpty(path) && Directory.Exists(path))
+		if (!string.IsNullOrEmpty(path) && Directory.Exists(path) && HasManagedAssemblies(path))
 			_unityInstallations.Add(path);
+	}
+
+	private static bool HasManagedAssemblies(string path)
+	{
+		// Skip partial installations (uninstall leftovers, stripped editors)
+		return File.Exists(Path.Combine(path, "Managed", "UnityEditor.dll"))
+			|| File.Exists(Path.Combine(path, "Resources", "Scripting", "Managed", "UnityEditor.dll"));
 	}
 }


### PR DESCRIPTION
On Windows, uninstall leftovers and stripped editors can remain under the Unity Hub folder with only a `Resources` subfolder (no `Managed` assemblies). `UnityPath` registers them as valid installations, and since installations are enumerated in descending order, such a folder can end up first: `FirstInstallation()` then points to a folder without managed assemblies and every test fails with missing `UnityEngine`/`UnityEditor` references.

Only register an installation if `UnityEditor.dll` is actually present, checking both the classic `Managed` layout and the macOS 6000.3+ `Resources/Scripting/Managed` layout (mirroring `DiagnosticVerifier.UnityAssemblies()`).