### PR TITLE
Migrate tests to xUnit 4 and MTP retry

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -129,8 +129,8 @@ When you need to search the unity API, you can use :
 # Build
 dotnet build .\src\Microsoft.Unity.Analyzers.slnx
 
-# Run tests
-dotnet test .\src\Microsoft.Unity.Analyzers.slnx --filter FullyQualifiedName!~ConsistencyTests
+# Run tests with Microsoft Testing Platform
+dotnet .\src\Microsoft.Unity.Analyzers.Tests\bin\Debug\net10.0\Microsoft.Unity.Analyzers.Tests.dll --retry-failed-tests 3 --filter-not-class Microsoft.Unity.Analyzers.Tests.ConsistencyTests
 ```
 
 Indeed we want to skip ConsistencyTests when developping new diagnostics because those tests are doing http-requests on documentation.

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -14,6 +14,7 @@ on:
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
+  TESTINGPLATFORM_TELEMETRY_OPTOUT: 1
   UNITY_HASH: '1c7db571dde0'
   UNITY_FULL_VERSION: '6000.3.8f1'
   HUSKY: 0
@@ -89,14 +90,14 @@ jobs:
 
     - name: Test context (main)
       if: github.ref == 'refs/heads/main'
-      run: echo "TEST_FILTER=." >> $GITHUB_ENV
+      run: echo "TEST_ARGUMENTS=--retry-failed-tests 3" >> "$GITHUB_ENV"
       shell: bash
     
     - name: Test context (feature)    
       if: github.ref != 'refs/heads/main'
-      run: echo "TEST_FILTER=FullyQualifiedName!~ConsistencyTests" >> $GITHUB_ENV
+      run: echo "TEST_ARGUMENTS=--retry-failed-tests 3 --filter-not-class Microsoft.Unity.Analyzers.Tests.ConsistencyTests" >> "$GITHUB_ENV"
       shell: bash
 
     - name: Test
-      run: dotnet test -c Debug ./src/Microsoft.Unity.Analyzers.Tests --filter ${{env.TEST_FILTER}}
+      run: dotnet ./src/Microsoft.Unity.Analyzers.Tests/bin/Debug/net10.0/Microsoft.Unity.Analyzers.Tests.dll $TEST_ARGUMENTS
       shell: bash

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ For unit-testing, we require Unity to be installed. We recommend using the lates
 Compiling the solution:
 `dotnet build .\src\Microsoft.Unity.Analyzers.slnx`
 
-Running the unit tests:
-`dotnet test .\src\Microsoft.Unity.Analyzers.slnx`
+Running the unit tests with Microsoft Testing Platform and retrying failures up to three times:
+`dotnet .\src\Microsoft.Unity.Analyzers.Tests\bin\Debug\net10.0\Microsoft.Unity.Analyzers.Tests.dll --retry-failed-tests 3`
 
 You can open `.\src\Microsoft.Unity.Analyzers.slnx` in your favorite IDE to work on the analyzers and run/debug the tests.
 
@@ -91,6 +91,4 @@ Example for creating `CustomSuppressor` and `CustomSuppressorTests` classes :
 
 This project welcomes contributions and suggestions.
 Please have a look at our [Guidelines](CONTRIBUTING.md) for contributing.
-
-
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,9 +18,10 @@
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.14.2120" />
     <!-- Tests -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.Retry" Version="2.3.3" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.11" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
     <!-- Misc -->
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>

--- a/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
+++ b/src/Microsoft.Unity.Analyzers.Tests/Microsoft.Unity.Analyzers.Tests.csproj
@@ -5,12 +5,14 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <NoWarn>NU1608;VSTHRD200</NoWarn>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.Retry" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />    
     <PackageReference Include="System.Reflection.MetadataLoadContext" />
     <PackageReference Include="xunit.v3" />


### PR DESCRIPTION
<!-- Title: Migrate tests to xUnit 4 and MTP retry -->

## Summary

Migrate the analyzer test project to xUnit.net v3 4.0.0 and Microsoft.Testing.Platform (MTP) v2, and replace the legacy VSTest CI path with native MTP execution and retry support.

This change:

- updates `xunit.v3` and `xunit.runner.visualstudio` to 4.0.0
- adds `Microsoft.Testing.Extensions.Retry` 2.3.3
- configures the test project with `UseMicrosoftTestingPlatformRunner`
- runs the built test assembly directly instead of invoking VSTest-mode `dotnet test`
- enables up to three retries for failed tests
- preserves the existing distinction between full main-branch runs and feature/PR runs that exclude `ConsistencyTests`
- updates the README, CI documentation, and Copilot instructions with the new runner commands
- opts CI out of Microsoft Testing Platform telemetry

This also unblocks the corresponding xUnit 4 migrations in VSTU and VSTUC, which consume this repository through the `external\VSTUAnalyzers` submodule.

## CI behavior

The main branch runs the complete suite:

```text
dotnet ./src/Microsoft.Unity.Analyzers.Tests/bin/Debug/net10.0/Microsoft.Unity.Analyzers.Tests.dll --retry-failed-tests 3
```

Feature and pull-request branches exclude the documentation-dependent consistency tests:

```text
dotnet ./src/Microsoft.Unity.Analyzers.Tests/bin/Debug/net10.0/Microsoft.Unity.Analyzers.Tests.dll --retry-failed-tests 3 --filter-not-class Microsoft.Unity.Analyzers.Tests.ConsistencyTests
```

The generated xUnit 4 runner help was used to confirm the retry and exact-class filter syntax rather than relying on the previous VSTest filter format.

## Validation

Validation was performed with .NET SDK 10.0.400:

- built the complete solution successfully with no warnings or errors
- ran the feature/PR command successfully: 472 tests passed
- ran the full main-branch command successfully: 476 tests passed
- confirmed through generated `--help` output that `--retry-failed-tests` and `--filter-not-class` are available
- confirmed through generated `--info` output that Microsoft.Testing.Platform 2.3.3, the xUnit 4.0.0 provider, and Retry 2.3.3 are active
