### PR TITLE
Add UNT0045 for non-allocating array access

### DIFF
--- a/doc/UNT0045.md
+++ b/doc/UNT0045.md
@@ -1,0 +1,80 @@
+# UNT0045 Use non-allocating array access
+
+Reading `Collision.contacts`, `Collision2D.contacts`, or `Input.touches` can allocate an array. When only its length or a single element is needed, use the corresponding non-allocating API instead:
+
+- `Collision.contacts.Length` and `Collision2D.contacts.Length`: use `contactCount`.
+- `Collision.contacts[index]` and `Collision2D.contacts[index]`: use `GetContact(index)`.
+- `Input.touches.Length`: use `Input.touchCount`.
+- `Input.touches[index]`: use `Input.GetTouch(index)`.
+
+This rule applies to the legacy `UnityEngine.Input` API, not the Input System package.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using UnityEngine;
+
+class Example : MonoBehaviour
+{
+    void OnCollisionEnter(Collision collision)
+    {
+        if (collision.contacts.Length > 0)
+            Debug.Log(collision.contacts[0].normal);
+    }
+
+    void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (collision.contacts.Length > 0)
+            Debug.Log(collision.contacts[0].normal);
+    }
+
+    void Update()
+    {
+        if (Input.touches.Length > 0)
+            Debug.Log(Input.touches[0].position);
+    }
+}
+```
+
+## Solution
+
+```csharp
+using UnityEngine;
+
+class Example : MonoBehaviour
+{
+    void OnCollisionEnter(Collision collision)
+    {
+        if (collision.contactCount > 0)
+            Debug.Log(collision.GetContact(0).normal);
+    }
+
+    void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (collision.contactCount > 0)
+            Debug.Log(collision.GetContact(0).normal);
+    }
+
+    void Update()
+    {
+        if (Input.touchCount > 0)
+            Debug.Log(Input.GetTouch(0).position);
+    }
+}
+```
+
+A code fix is offered for this diagnostic to automatically apply these changes.
+
+## Scope
+
+The rule targets direct `.Length` accesses and individual value reads with an index compatible with the getter's `int` parameter. The replacement API must be available in the referenced Unity assemblies.
+
+Only the listed Unity receiver types are supported. Custom subclasses are excluded because they can hide the replacement member.
+
+It does not rewrite array assignments, `ref`/`out`/`in` accesses, mutations or instance method calls on array elements, whole-array usage, or `foreach` loops. An index containing `await` is also excluded: obtaining a snapshot before suspension is different from reading the current state afterward.
+
+## Invalid indices
+
+Both array indexing and the recommended getter APIs check bounds. However, their exceptions are not necessarily identical. For example, accessing `collision.contacts[index]` with an invalid index throws `IndexOutOfRangeException`, while `collision.GetContact(index)` throws `ArgumentOutOfRangeException`.
+
+The code fix follows Unity's recommendation to use non-allocating access, but does not preserve the exact exception type for invalid indices. Code that catches a specific bounds exception should account for this difference.

--- a/doc/index.md
+++ b/doc/index.md
@@ -46,6 +46,7 @@ ID | Title | Category
 [UNT0042](UNT0042.md) | `Mesh` array property accessed in loop | Performance
 [UNT0043](UNT0043.md) | Possible typo in conditional compilation symbol | Correctness
 [UNT0044](UNT0044.md) | Avoid temporary strings when setting TextMeshPro text | Performance
+[UNT0045](UNT0045.md) | Use non-allocating array access | Performance
 
 # Diagnostic Suppressors
 

--- a/src/Microsoft.Unity.Analyzers.Tests/NonAllocatingArrayAccessTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/NonAllocatingArrayAccessTests.cs
@@ -1,0 +1,189 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests;
+
+public class NonAllocatingArrayAccessTests : BaseCodeFixVerifierTest<NonAllocatingArrayAccessAnalyzer, NonAllocatingArrayAccessCodeFix>
+{
+	[Theory]
+	[InlineData("Collision", "value.contacts.Length", "value.contactCount", "contacts", "contactCount")]
+	[InlineData("Collision2D", "value.contacts.Length", "value.contactCount", "contacts", "contactCount")]
+	[InlineData("object", "Input.touches.Length", "Input.touchCount", "touches", "touchCount")]
+	[InlineData("Collision", "value.contacts[i]", "value.GetContact(i)", "contacts", "GetContact")]
+	[InlineData("Collision2D", "value.contacts[i]", "value.GetContact(i)", "contacts", "GetContact")]
+	[InlineData("object", "Input.touches[i]", "Input.GetTouch(i)", "touches", "GetTouch")]
+	[InlineData("Collision", "value.contacts[0].normal", "value.GetContact(0).normal", "contacts", "GetContact")]
+	[InlineData("Collision2D", "value.contacts[0].normal", "value.GetContact(0).normal", "contacts", "GetContact")]
+	[InlineData("object", "Input.touches[0].position", "Input.GetTouch(0).position", "touches", "GetTouch")]
+	[InlineData("Collision", "value.contacts[i++]", "value.GetContact(i++)", "contacts", "GetContact")]
+	[InlineData("Collision2D", "value.contacts[i++]", "value.GetContact(i++)", "contacts", "GetContact")]
+	[InlineData("object", "Input.touches[i++]", "Input.GetTouch(i++)", "touches", "GetTouch")]
+	public async Task NonAllocatingRead(string type, string expression, string fixedExpression, string property, string replacement)
+	{
+		var test = Source(type, $"Debug.Log({expression});");
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(8, 19)
+			.WithArguments(replacement, property);
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+		await VerifyCSharpFixAsync(test, Source(type, $"Debug.Log({fixedExpression});"));
+	}
+
+	[Theory]
+	[InlineData("InputAlias.touches.Length", "InputAlias.touchCount", "touchCount")]
+	[InlineData("InputAlias.touches[i]", "InputAlias.GetTouch(i)", "GetTouch")]
+	public async Task AliasedType(string expression, string fixedExpression, string replacement)
+	{
+		const string alias = "using InputAlias = UnityEngine.Input;";
+		var test = Source("object", $"Debug.Log({expression});", alias);
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(8, 19)
+			.WithArguments(replacement, "touches");
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+		await VerifyCSharpFixAsync(test, Source("object", $"Debug.Log({fixedExpression});", alias));
+	}
+
+	[Theory]
+	[InlineData("value./* property */contacts[i /* index */]", "value./* property */GetContact(i /* index */)", "GetContact")]
+	[InlineData("value.contacts /* array */.Length", "value.contactCount /* array */", "contactCount")]
+	public async Task PreserveTrivia(string expression, string fixedExpression, string replacement)
+	{
+		var test = Source("Collision", $"Debug.Log({expression});");
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(8, 19)
+			.WithArguments(replacement, "contacts");
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+		await VerifyCSharpFixAsync(test, Source("Collision", $"Debug.Log({fixedExpression});"));
+	}
+
+	[Theory]
+	[InlineData("Collision", "Debug.Log(value.contactCount);")]
+	[InlineData("Collision", "Debug.Log(value.GetContact(i));")]
+	[InlineData("Collision2D", "Debug.Log(value.contactCount);")]
+	[InlineData("Collision2D", "Debug.Log(value.GetContact(i));")]
+	[InlineData("object", "Debug.Log(Input.touchCount);")]
+	[InlineData("object", "Debug.Log(Input.GetTouch(i));")]
+	[InlineData("Collision", "Debug.Log(value.contacts);")]
+	[InlineData("object", "Debug.Log(Input.touches);")]
+	[InlineData("Collision", "foreach (var contact in value.contacts) Debug.Log(contact);")]
+	[InlineData("object", "foreach (var touch in Input.touches) Debug.Log(touch);")]
+	[InlineData("Collision", "Debug.Log(value.contacts.LongLength);")]
+	[InlineData("Collision", "Debug.Log(nameof(value.contacts.Length));")]
+	[InlineData("object", "Debug.Log(nameof(Input.touches.Length));")]
+	[InlineData("ContactPoint[]", "Debug.Log(value.Length);")]
+	[InlineData("Touch[]", "Debug.Log(value[i]);")]
+	public async Task OtherUsage(string type, string statement)
+	{
+		await VerifyCSharpDiagnosticAsync(Source(type, statement));
+	}
+
+	[Theory]
+	[InlineData("Collision", "value.contacts[i] = default;")]
+	[InlineData("Collision", "(value.contacts[i], i) = (default, 0);")]
+	[InlineData("Collision", "ref var contact = ref value.contacts[i]; Debug.Log(contact);")]
+	[InlineData("Collision", "void Modify(ref ContactPoint p) { } Modify(ref value.contacts[i]);")]
+	[InlineData("Collision2D", "void Modify(out ContactPoint2D p) { p = default; } Modify(out value.contacts[i]);")]
+	[InlineData("object", "void Inspect(in Touch touch) { } Inspect(in Input.touches[i]);")]
+	[InlineData("Collision", "void Inspect(in ContactPoint p) { } Inspect(value.contacts[i]);")]
+	[InlineData("Collision2D", "void Inspect(in ContactPoint2D p) { } Inspect(value.contacts[i]);")]
+	[InlineData("object", "void Inspect(in Touch touch) { } Inspect((Input.touches[i]));")]
+	[InlineData("Collision", "Debug.Log(value.contacts[i].ToString());")]
+	[InlineData("object", "Input.touches[i].position = Vector2.zero;")]
+	[InlineData("object", "Input.touches[i]!.position = Vector2.zero;")]
+	[InlineData("Collision", "ref var contact = ref value.contacts[i]!; Debug.Log(contact);")]
+	[InlineData("object", "Input.touches[i].tapCount++;")]
+	[InlineData("object", "Input.touches[i].tapCount += 1;")]
+	[InlineData("Collision", "Debug.Log(value.contacts[(long)i]);")]
+	[InlineData("Collision2D", "Debug.Log(value.contacts[(uint)i]);")]
+	[InlineData("object", "Debug.Log(Input.touches[(long)i]);")]
+	public async Task NotAValueReadWithIntIndex(string type, string statement)
+	{
+		await VerifyCSharpDiagnosticAsync(Source(type, statement));
+	}
+
+	[Fact]
+	public async Task UnrelatedProperty()
+	{
+		var test = Source("Other", "Debug.Log(value.contacts.Length); Debug.Log(value.contacts[i]);") + @"
+class Other
+{
+    public int[] contacts => new int[1];
+    public int contactCount => 1;
+    public int GetContact(int index) => 0;
+}";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Theory]
+	[InlineData("value.contacts.Length")]
+	[InlineData("value.contacts[i]")]
+	public async Task HiddenReplacement(string expression)
+	{
+		var test = Source("DerivedCollision", $"Debug.Log({expression});") + @"
+class DerivedCollision : Collision
+{
+    public new int contactCount => 99;
+    public new ContactPoint GetContact(int index) => default;
+}";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task MultipleReads()
+	{
+		var test = Source("Collision", "Debug.Log(value.contacts.Length + value.contacts[i].point.x);");
+		var fixedTest = Source("Collision", "Debug.Log(value.contactCount + value.GetContact(i).point.x);");
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task ReceiverEvaluatedOnce()
+	{
+		var test = Source("Collision", "Collision GetCollision() => value; Debug.Log(GetCollision().contacts[i]);");
+		var fixedTest = Source("Collision", "Collision GetCollision() => value; Debug.Log(GetCollision().GetContact(i));");
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task AwaitedIndex()
+	{
+		const string test = @"
+using UnityEngine;
+using System.Threading.Tasks;
+
+class Example
+{
+    async Task<ContactPoint> Read(Collision collision, Task<int> index)
+    {
+        return collision.contacts[await index];
+    }
+}";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	private static string Source(string type, string statement, string extraUsing = "")
+	{
+		return $@"
+using UnityEngine;
+{extraUsing}
+class Example : MonoBehaviour
+{{
+    void Method({type} value, int i)
+    {{
+        {statement}
+    }}
+}}";
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/NonAllocatingArrayAccess.cs
+++ b/src/Microsoft.Unity.Analyzers/NonAllocatingArrayAccess.cs
@@ -1,0 +1,257 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.Unity.Analyzers.Resources;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Unity.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class NonAllocatingArrayAccessAnalyzer : DiagnosticAnalyzer
+{
+	private const string RuleId = "UNT0045";
+
+	internal static readonly DiagnosticDescriptor Rule = new(
+		id: RuleId,
+		title: Strings.NonAllocatingArrayAccessDiagnosticTitle,
+		messageFormat: Strings.NonAllocatingArrayAccessDiagnosticMessageFormat,
+		category: DiagnosticCategory.Performance,
+		defaultSeverity: DiagnosticSeverity.Info,
+		isEnabledByDefault: true,
+		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
+		description: Strings.NonAllocatingArrayAccessDiagnosticDescription);
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+	private static readonly Dictionary<string, (Type[] Types, string Count, string Element)> Candidates = new()
+	{
+		["contacts"] = ([typeof(UnityEngine.Collision), typeof(UnityEngine.Collision2D)], "contactCount", "GetContact"),
+		["touches"] = ([typeof(UnityEngine.Input)], "touchCount", "GetTouch")
+	};
+
+	public override void Initialize(AnalysisContext context)
+	{
+		context.EnableConcurrentExecution();
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+		context.RegisterSyntaxNodeAction(AnalyzeAccess, SyntaxKind.SimpleMemberAccessExpression, SyntaxKind.ElementAccessExpression);
+	}
+
+	private static void AnalyzeAccess(SyntaxNodeAnalysisContext context)
+	{
+		if (!TryGetAccess(context.Node, out var arrayAccess, out var candidate))
+			return;
+
+		var model = context.SemanticModel;
+		if (model.GetSymbolInfo(arrayAccess, context.CancellationToken).Symbol is not IPropertySymbol property
+			|| property.Type is not IArrayTypeSymbol arrayType
+			|| !IsCandidateType(property.ContainingType, candidate.Types))
+			return;
+
+		if (!SymbolEqualityComparer.Default.Equals(model.GetTypeInfo(arrayAccess.Expression, context.CancellationToken).Type, property.ContainingType))
+			return;
+
+		if (context.Node is ElementAccessExpressionSyntax element)
+		{
+			if (model.GetTypeInfo(element.ArgumentList.Arguments[0].Expression, context.CancellationToken).ConvertedType?.SpecialType != SpecialType.System_Int32)
+				return;
+
+			if (model.GetOperation(element, context.CancellationToken)?.Parent is IArgumentOperation { Parameter.RefKind: not RefKind.None })
+				return;
+		}
+
+		if (!HasReplacement(property, arrayType.ElementType, candidate.Member, context.Node is ElementAccessExpressionSyntax))
+			return;
+
+		context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation(), candidate.Member, arrayAccess.Name.Identifier.ValueText));
+	}
+
+	internal static bool TryGetAccess(SyntaxNode node, [NotNullWhen(true)] out MemberAccessExpressionSyntax? arrayAccess,
+		out (Type[] Types, string Member) candidate)
+	{
+		arrayAccess = null;
+		candidate = default;
+
+		var expression = node switch
+		{
+			MemberAccessExpressionSyntax member when member.Name.Identifier.ValueText == nameof(Array.Length) => member.Expression,
+			ElementAccessExpressionSyntax element when element.ArgumentList.Arguments.Count == 1 => element.Expression,
+			_ => null
+		};
+
+		if (expression is not MemberAccessExpressionSyntax memberAccess
+			|| !Candidates.TryGetValue(memberAccess.Name.Identifier.ValueText, out var entry))
+			return false;
+
+		if (node.ContainsDirectives || IsInsideNameOf(node))
+			return false;
+
+		if (node is ElementAccessExpressionSyntax indexer)
+		{
+			if (!IsElementRead(indexer))
+				return false;
+
+			foreach (var descendant in indexer.ArgumentList.Arguments[0].Expression.DescendantNodesAndSelf())
+			{
+				if (descendant is AwaitExpressionSyntax)
+					return false;
+			}
+		}
+
+		arrayAccess = memberAccess;
+		candidate = (entry.Types, node is ElementAccessExpressionSyntax ? entry.Element : entry.Count);
+		return true;
+	}
+
+	private static bool IsCandidateType(ITypeSymbol type, Type[] candidates)
+	{
+		foreach (var candidate in candidates)
+		{
+			if (type.Matches(candidate))
+				return true;
+		}
+
+		return false;
+	}
+
+	private static bool HasReplacement(IPropertySymbol property, ITypeSymbol elementType, string name, bool isElement)
+	{
+		foreach (var member in property.ContainingType.GetMembers(name))
+		{
+			if (member.IsStatic != property.IsStatic)
+				continue;
+
+			if (!isElement && member is IPropertySymbol { IsIndexer: false } count
+				&& count.Type.SpecialType == SpecialType.System_Int32
+				&& count.GetMethod?.DeclaredAccessibility == Accessibility.Public)
+				return true;
+
+			if (isElement && member is IMethodSymbol method
+				&& method.DeclaredAccessibility == Accessibility.Public
+				&& method.Parameters.Length == 1
+				&& method.Parameters[0].RefKind == RefKind.None
+				&& method.Parameters[0].Type.SpecialType == SpecialType.System_Int32
+				&& SymbolEqualityComparer.Default.Equals(method.ReturnType, elementType))
+				return true;
+		}
+
+		return false;
+	}
+
+	private static bool IsInsideNameOf(SyntaxNode node)
+	{
+		for (var parent = node.Parent; parent != null; parent = parent.Parent)
+		{
+			if (parent is InvocationExpressionSyntax { Expression: IdentifierNameSyntax { Identifier.ValueText: "nameof" } })
+				return true;
+		}
+
+		return false;
+	}
+
+	private static bool IsElementRead(ElementAccessExpressionSyntax element)
+	{
+		SyntaxNode current = element;
+		while (true)
+		{
+			switch (current.Parent)
+			{
+				case ParenthesizedExpressionSyntax parentheses:
+					current = parentheses;
+					continue;
+				case PostfixUnaryExpressionSyntax postfix when postfix.IsKind(SyntaxKind.SuppressNullableWarningExpression):
+					current = postfix;
+					continue;
+				case MemberAccessExpressionSyntax member when member.Expression == current:
+					current = member;
+					continue;
+				case ArgumentSyntax { Parent: TupleExpressionSyntax tuple }:
+					current = tuple;
+					continue;
+			}
+
+			break;
+		}
+
+		// Array elements are variables; getter results are values.
+		return current.Parent switch
+		{
+			AssignmentExpressionSyntax assignment when assignment.Left == current => false,
+			ArgumentSyntax argument when !argument.RefKindKeyword.IsKind(SyntaxKind.None) => false,
+			RefExpressionSyntax => false,
+			PrefixUnaryExpressionSyntax prefix when prefix.IsKind(SyntaxKind.PreIncrementExpression)
+				|| prefix.IsKind(SyntaxKind.PreDecrementExpression) || prefix.IsKind(SyntaxKind.AddressOfExpression) => false,
+			PostfixUnaryExpressionSyntax postfix when postfix.IsKind(SyntaxKind.PostIncrementExpression)
+				|| postfix.IsKind(SyntaxKind.PostDecrementExpression) => false,
+			InvocationExpressionSyntax invocation when invocation.Expression == current => false,
+			_ => true
+		};
+	}
+}
+
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+public class NonAllocatingArrayAccessCodeFix : CodeFixProvider
+{
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(NonAllocatingArrayAccessAnalyzer.Rule.Id);
+
+	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+	{
+		var access = await context.GetFixableNodeAsync<ExpressionSyntax>();
+		if (access == null || !NonAllocatingArrayAccessAnalyzer.TryGetAccess(access, out var arrayAccess, out var candidate))
+			return;
+
+		context.RegisterCodeFix(
+			CodeAction.Create(
+				Strings.NonAllocatingArrayAccessCodeFixTitle,
+				ct => ReplaceAccessAsync(context.Document, access, arrayAccess, candidate.Member, ct),
+				NonAllocatingArrayAccessAnalyzer.Rule.Id),
+			context.Diagnostics);
+	}
+
+	private static async Task<Document> ReplaceAccessAsync(Document document, ExpressionSyntax access,
+		MemberAccessExpressionSyntax arrayAccess, string replacementName, CancellationToken cancellationToken)
+	{
+		var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+		if (root == null)
+			return document;
+
+		ExpressionSyntax replacement = arrayAccess.WithName(IdentifierName(replacementName).WithTriviaFrom(arrayAccess.Name));
+		if (access is ElementAccessExpressionSyntax element)
+		{
+			replacement = InvocationExpression(replacement,
+				ArgumentList(
+					Token(SyntaxKind.OpenParenToken).WithTriviaFrom(element.ArgumentList.OpenBracketToken),
+					element.ArgumentList.Arguments,
+					Token(SyntaxKind.CloseParenToken).WithTriviaFrom(element.ArgumentList.CloseBracketToken)))
+				.WithTriviaFrom(access);
+		}
+		else if (access is MemberAccessExpressionSyntax length)
+		{
+			var trailingTrivia = arrayAccess.GetTrailingTrivia()
+				.AddRange(length.OperatorToken.LeadingTrivia)
+				.AddRange(length.OperatorToken.TrailingTrivia)
+				.AddRange(length.Name.GetLeadingTrivia())
+				.AddRange(length.GetTrailingTrivia());
+
+			replacement = replacement.WithLeadingTrivia(access.GetLeadingTrivia()).WithTrailingTrivia(trailingTrivia);
+		}
+
+		return document.WithSyntaxRoot(root.ReplaceNode(access, replacement));
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -916,6 +916,42 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use non-allocating access.
+        /// </summary>
+        internal static string NonAllocatingArrayAccessCodeFixTitle {
+            get {
+                return ResourceManager.GetString("NonAllocatingArrayAccessCodeFixTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use non-allocating Unity APIs instead of allocating an array to read its length or an element..
+        /// </summary>
+        internal static string NonAllocatingArrayAccessDiagnosticDescription {
+            get {
+                return ResourceManager.GetString("NonAllocatingArrayAccessDiagnosticDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;{0}&apos; instead of &apos;{1}&apos; to avoid allocating an array..
+        /// </summary>
+        internal static string NonAllocatingArrayAccessDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("NonAllocatingArrayAccessDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use non-allocating array access.
+        /// </summary>
+        internal static string NonAllocatingArrayAccessDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("NonAllocatingArrayAccessDiagnosticTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Use the generic form of GetComponent.
         /// </summary>
         internal static string NonGenericGetComponentCodeFixTitle {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -700,4 +700,16 @@
   <data name="TextMeshProSetTextDiagnosticTitle" xml:space="preserve">
     <value>Avoid temporary strings when setting TextMeshPro text</value>
   </data>
+  <data name="NonAllocatingArrayAccessCodeFixTitle" xml:space="preserve">
+    <value>Use non-allocating access</value>
+  </data>
+  <data name="NonAllocatingArrayAccessDiagnosticDescription" xml:space="preserve">
+    <value>Use non-allocating Unity APIs instead of allocating an array to read its length or an element.</value>
+  </data>
+  <data name="NonAllocatingArrayAccessDiagnosticMessageFormat" xml:space="preserve">
+    <value>Use '{0}' instead of '{1}' to avoid allocating an array.</value>
+  </data>
+  <data name="NonAllocatingArrayAccessDiagnosticTitle" xml:space="preserve">
+    <value>Use non-allocating array access</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #493

#### Checklist
- [x] I have read the [Contribution Guide](https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/main/CONTRIBUTING.md).
- [x] There is a tracking issue describing the agreed new diagnostic: #493.
- [x] I have added tests that prove the feature works.
- [x] I have added the necessary documentation.

#### Short description of what this resolves:

Adds **UNT0045: Use non-allocating array access** with one shared analyzer and code fix for both length and indexed reads of `Collision.contacts`, `Collision2D.contacts`, and legacy `Input.touches`.

The fix uses `contactCount` / `GetContact(index)` for collisions and `Input.touchCount` / `Input.GetTouch(index)` for touches instead of requesting an array.

#### Changes proposed in this pull request:
- Use a fixed candidate map and syntax-first filtering. Semantic queries occur only after a supported syntax candidate is found.
- Share the two rewrite paths, retaining receiver/index expressions without duplicating their evaluation and preserving trivia.
- Exclude writes, reference-taking uses, incompatible index types, `nameof`, awaited indices, and custom receiver subclasses. Require the replacement API to exist in the referenced Unity assemblies.
- Add focused diagnostic and code-fix coverage, localized resources, and the UNT0045 documentation/catalog entry. Existing analyzers are unchanged.

Both forms retain bounds checking, but invalid-index exception types can differ. The documentation explicitly notes `IndexOutOfRangeException` for array indexing versus `ArgumentOutOfRangeException` for `Collision.GetContact`.

#### Validation
- Test project builds with no warnings or errors.
- All 56 targeted `NonAllocatingArrayAccessTests` cases pass.
- Husky pre-commit formatting completed successfully.