### PR TITLE
Add UNT0046 to cache Shader.PropertyToID results

### DIFF
--- a/doc/UNT0041.md
+++ b/doc/UNT0041.md
@@ -46,3 +46,5 @@ class Example : MonoBehaviour
 ```
 
 A code fix is offered for this diagnostic to automatically extract the string literal to a cached hash field.
+
+The fix reuses an accessible `static readonly int` field initialized with `Animator.StringToHash` for the same string when possible. Otherwise, it creates a field whose name does not conflict with existing members or local variables.

--- a/doc/UNT0041.md
+++ b/doc/UNT0041.md
@@ -46,5 +46,3 @@ class Example : MonoBehaviour
 ```
 
 A code fix is offered for this diagnostic to automatically extract the string literal to a cached hash field.
-
-The fix reuses an accessible `static readonly int` field initialized with `Animator.StringToHash` for the same string when possible. Otherwise, it creates a field whose name does not conflict with existing members or local variables.

--- a/doc/UNT0046.md
+++ b/doc/UNT0046.md
@@ -1,6 +1,6 @@
-# UNT0046 Cache repeated Shader.PropertyToID calls
+# UNT0046 Cache Shader.PropertyToID calls
 
-When code calls `Shader.PropertyToID` repeatedly with the same literal property name, compute the ID once and store it in a `static readonly int` field.
+`Shader.PropertyToID` converts a shader property name into an integer ID. Calling it each time a script runs, such as in `Update`, recomputes the ID, which impacts performance.
 
 ## Examples of patterns that are flagged by this analyzer
 
@@ -9,19 +9,20 @@ using UnityEngine;
 
 class Example : MonoBehaviour
 {
-    void SetColor(Material material, Color color)
-    {
-        material.SetColor(Shader.PropertyToID("_Color"), color);
-    }
+    private Material _material;
 
-    Color GetColor(Material material)
+    void Update()
     {
-        return material.GetColor(Shader.PropertyToID("_Color"));
+        // UNT0046: Cache Shader.PropertyToID calls
+        _material.SetColor(Shader.PropertyToID("_Color"), Color.red);
+        _material.SetFloat(Shader.PropertyToID("_Glossiness"), 0.5f);
     }
 }
 ```
 
 ## Solution
+
+Pre-compute the ID using `Shader.PropertyToID` and store it in a static readonly field:
 
 ```csharp
 using UnityEngine;
@@ -29,31 +30,16 @@ using UnityEngine;
 class Example : MonoBehaviour
 {
     private static readonly int ColorId = Shader.PropertyToID("_Color");
+    private static readonly int GlossinessId = Shader.PropertyToID("_Glossiness");
 
-    void SetColor(Material material, Color color)
-    {
-        material.SetColor(ColorId, color);
-    }
+    private Material _material;
 
-    Color GetColor(Material material)
+    void Update()
     {
-        return material.GetColor(ColorId);
+        _material.SetColor(ColorId, Color.red);
+        _material.SetFloat(GlossinessId, 0.5f);
     }
 }
 ```
 
-The code fix replaces all matching calls for that name in the type declaration. It reuses an accessible `static readonly int` field initialized by the same call when possible, or creates a field with a name that does not conflict with existing members or local variables.
-
-## Scope
-
-- At least two value-producing calls must use the same string literal in one class, struct, or record class declaration. Nonliteral arguments, including constant references, concatenations, and `nameof` expressions, are excluded.
-- Calls must resolve to `UnityEngine.Shader.PropertyToID(string)`. Unrelated methods with the same name are ignored.
-- Field initializers and property initializers do not count: they may already cache their values. Calls whose return value is discarded are also excluded.
-- Nested types and separate declarations of a partial type are counted independently.
-- A single call, even inside `Update` or a loop, is not reported. The rule does not infer runtime call frequency.
-
-Each diagnostic offers one fix for a repeated name. Batch Fix All is not offered because independently generated fields can conflict within the same type.
-
-## ID lifetime
-
-Shader property IDs are stable during a run, but are not guaranteed to match between runs or machines. The fix keeps the call to `Shader.PropertyToID` in the field initializer; it does not replace it with a hard-coded integer. Do not serialize these IDs or send them over the network.
+A code fix is offered for this diagnostic to automatically extract the call to a cached property ID field.

--- a/doc/UNT0046.md
+++ b/doc/UNT0046.md
@@ -1,0 +1,59 @@
+# UNT0046 Cache repeated Shader.PropertyToID calls
+
+When code calls `Shader.PropertyToID` repeatedly with the same literal property name, compute the ID once and store it in a `static readonly int` field.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using UnityEngine;
+
+class Example : MonoBehaviour
+{
+    void SetColor(Material material, Color color)
+    {
+        material.SetColor(Shader.PropertyToID("_Color"), color);
+    }
+
+    Color GetColor(Material material)
+    {
+        return material.GetColor(Shader.PropertyToID("_Color"));
+    }
+}
+```
+
+## Solution
+
+```csharp
+using UnityEngine;
+
+class Example : MonoBehaviour
+{
+    private static readonly int ColorId = Shader.PropertyToID("_Color");
+
+    void SetColor(Material material, Color color)
+    {
+        material.SetColor(ColorId, color);
+    }
+
+    Color GetColor(Material material)
+    {
+        return material.GetColor(ColorId);
+    }
+}
+```
+
+The code fix replaces all matching calls for that name in the type declaration. It reuses an accessible `static readonly int` field initialized by the same call when possible, or creates a field with a name that does not conflict with existing members or local variables.
+
+## Scope
+
+- At least two value-producing calls must use the same string literal in one class, struct, or record class declaration. Nonliteral arguments, including constant references, concatenations, and `nameof` expressions, are excluded.
+- Calls must resolve to `UnityEngine.Shader.PropertyToID(string)`. Unrelated methods with the same name are ignored.
+- Field initializers and property initializers do not count: they may already cache their values. Calls whose return value is discarded are also excluded.
+- Nested types and separate declarations of a partial type are counted independently.
+- A single call, even inside `Update` or a loop, is not reported. The rule does not infer runtime call frequency.
+
+Each diagnostic offers one fix for a repeated name. Batch Fix All is not offered because independently generated fields can conflict within the same type.
+
+## ID lifetime
+
+Shader property IDs are stable during a run, but are not guaranteed to match between runs or machines. The fix keeps the call to `Shader.PropertyToID` in the field initializer; it does not replace it with a hard-coded integer. Do not serialize these IDs or send them over the network.

--- a/doc/index.md
+++ b/doc/index.md
@@ -47,6 +47,7 @@ ID | Title | Category
 [UNT0043](UNT0043.md) | Possible typo in conditional compilation symbol | Correctness
 [UNT0044](UNT0044.md) | Avoid temporary strings when setting TextMeshPro text | Performance
 [UNT0045](UNT0045.md) | Use non-allocating array access | Performance
+[UNT0046](UNT0046.md) | Cache repeated Shader.PropertyToID calls | Performance
 
 # Diagnostic Suppressors
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -47,7 +47,7 @@ ID | Title | Category
 [UNT0043](UNT0043.md) | Possible typo in conditional compilation symbol | Correctness
 [UNT0044](UNT0044.md) | Avoid temporary strings when setting TextMeshPro text | Performance
 [UNT0045](UNT0045.md) | Use non-allocating array access | Performance
-[UNT0046](UNT0046.md) | Cache repeated Shader.PropertyToID calls | Performance
+[UNT0046](UNT0046.md) | Cache Shader.PropertyToID calls | Performance
 
 # Diagnostic Suppressors
 

--- a/src/Microsoft.Unity.Analyzers.Tests/AnimatorStringToHashTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/AnimatorStringToHashTests.cs
@@ -480,4 +480,52 @@ class Test : MonoBehaviour
 
 		await VerifyCSharpFixAsync(test, fixedTest);
 	}
+
+	[Theory]
+	[InlineData("    private static readonly int AttackHash = 42;\n")]
+	[InlineData("    private static readonly int AttackHash = Animator.StringToHash(\"Idle\");\n")]
+	[InlineData("    private static readonly int AttackHash = Shader.PropertyToID(\"Attack\");\n")]
+	[InlineData("    private static int AttackHash = Animator.StringToHash(\"Attack\");\n")]
+	public async Task UnrelatedHashFieldIsNotReused(string member)
+	{
+		var test = $@"
+using UnityEngine;
+
+class Test : MonoBehaviour
+{{
+{member}    private Animator _animator = null;
+
+    void Start()
+    {{
+        _animator.Play(""Attack"");
+    }}
+}}
+";
+		var fixedTest = test.Replace(member,
+				"    private static readonly int AttackHash1 = Animator.StringToHash(\"Attack\");\n" + member)
+			.Replace("_animator.Play(\"Attack\")", "_animator.Play(AttackHash1)");
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task ExistingHashFieldWithDifferentName()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Test : MonoBehaviour
+{
+    private static readonly int CachedAttack = Animator.StringToHash(""Attack"");
+    private Animator _animator = null;
+
+    void Start()
+    {
+        _animator.Play(""Attack"");
+    }
+}
+";
+
+		await VerifyCSharpFixAsync(test, test.Replace("_animator.Play(\"Attack\")", "_animator.Play(CachedAttack)"));
+	}
 }

--- a/src/Microsoft.Unity.Analyzers.Tests/ShaderPropertyToIDTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ShaderPropertyToIDTests.cs
@@ -1,0 +1,297 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Unity.Analyzers.Tests;
+
+public class ShaderPropertyToIDTests : BaseCodeFixVerifierTest<ShaderPropertyToIDAnalyzer, ShaderPropertyToIDCodeFix>
+{
+	private const string ColorCall = "Shader.PropertyToID(\"_Color\")";
+	private const string ColorField = "    private static readonly int ColorId = Shader.PropertyToID(\"_Color\");\n";
+
+	[Theory]
+	[InlineData("Shader.PropertyToID(\"_Color\")")]
+	[InlineData("Shader.PropertyToID(name: \"_Color\")")]
+	[InlineData("Shader.PropertyToID(@\"_Color\")")]
+	[InlineData("UnityEngine.Shader.PropertyToID(\"_Color\")")]
+	[InlineData("global::UnityEngine.Shader.PropertyToID(\"_Color\")")]
+	public async Task RepeatedLiteralCalls(string expression)
+	{
+		var test = Source(expression, ColorCall);
+		var diagnostic = ExpectDiagnostic()
+			.WithLocation(8, 16)
+			.WithArguments("_Color");
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+		await VerifyCSharpFixAsync(test, Source("ColorId", "ColorId", ColorField));
+	}
+
+	[Theory]
+	[InlineData("struct Example")]
+	[InlineData("record Example")]
+	[InlineData("static class Example", "static ")]
+	[InlineData("class Example<T> : MonoBehaviour")]
+	public async Task TypeDeclarations(string declaration, string methodModifier = "")
+	{
+		var test = Source(ColorCall, ColorCall, declaration: declaration, methodModifier: methodModifier);
+		var fixedTest = Source("ColorId", "ColorId", ColorField, declaration: declaration, methodModifier: methodModifier);
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Theory]
+	[InlineData("using S = UnityEngine.Shader;", "S.PropertyToID(\"_Color\")", "S")]
+	[InlineData("using static UnityEngine.Shader;", "PropertyToID(\"_Color\")", "")]
+	public async Task AliasedAndImportedCalls(string extraUsing, string expression, string factoryType)
+	{
+		var test = Source(expression, expression, extraUsing: extraUsing);
+		var factory = factoryType.Length == 0 ? "PropertyToID" : factoryType + ".PropertyToID";
+		var field = $"    private static readonly int ColorId = {factory}(\"_Color\");\n";
+
+		await VerifyCSharpFixAsync(test, Source("ColorId", "ColorId", field, extraUsing: extraUsing));
+	}
+
+	[Theory]
+	[InlineData("Shader.PropertyToID(PropertyName)")]
+	[InlineData("Shader.PropertyToID(\"_\" + \"Color\")")]
+	[InlineData("Shader.PropertyToID(nameof(PropertyName))")]
+	public async Task NonLiteralConstantsAreExcluded(string expression)
+	{
+		const string member = "    private const string PropertyName = \"_Color\";\n";
+		await VerifyCSharpDiagnosticAsync(Source(expression, expression, member));
+	}
+
+	[Fact]
+	public async Task LocalConstantsAreExcluded()
+	{
+		const string setup = "        const string propertyName = \"_Color\";\n";
+		const string calls = "Shader.PropertyToID(propertyName) + Shader.PropertyToID(propertyName)";
+		await VerifyCSharpDiagnosticAsync(Source(calls, "0", firstSetup: setup));
+	}
+
+	[Theory]
+	[InlineData("ColorId")]
+	[InlineData("ExistingColor")]
+	public async Task ReuseMatchingField(string name)
+	{
+		var member = $"    private static readonly int {name} = Shader.PropertyToID(\"_Color\");\n";
+		var test = Source(ColorCall, ColorCall, member);
+
+		await VerifyCSharpFixAsync(test, Source(name, name, member));
+	}
+
+	[Theory]
+	[InlineData("    private static readonly int ColorId = 42;\n")]
+	[InlineData("    private static readonly int ColorId = Shader.PropertyToID(\"_Other\");\n")]
+	[InlineData("    private static readonly int ColorId = Animator.StringToHash(\"_Color\");\n")]
+	[InlineData("    private static int ColorId = Shader.PropertyToID(\"_Color\");\n")]
+	[InlineData("    private readonly int ColorId = Shader.PropertyToID(\"_Color\");\n")]
+	[InlineData("    private int ColorId => 42;\n")]
+	public async Task DoNotReuseUnrelatedOrMutableMembers(string member)
+	{
+		var test = Source(ColorCall, ColorCall, member);
+		var newField = "    private static readonly int ColorId1 = Shader.PropertyToID(\"_Color\");\n";
+		if (member.Contains("=>"))
+			newField += "\n";
+
+		await VerifyCSharpFixAsync(test, Source("ColorId1", "ColorId1", newField + member));
+	}
+
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public async Task AvoidLocalNameConflicts(bool existingField)
+	{
+		var member = existingField ? ColorField : "";
+		var test = Source(ColorCall + " + ColorId", ColorCall, member, firstSetup: "        var ColorId = 42;\n");
+		var newField = "    private static readonly int ColorId1 = Shader.PropertyToID(\"_Color\");\n";
+		var fixedTest = Source("ColorId1 + ColorId", "ColorId1", newField + member, firstSetup: "        var ColorId = 42;\n");
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Theory]
+	[InlineData("_Main-Tex", "MainTexId")]
+	[InlineData("1st Texture", "_1stTextureId")]
+	[InlineData("", "Id")]
+	public async Task FieldNames(string property, string fieldName)
+	{
+		var call = $"Shader.PropertyToID(\"{property}\")";
+		var field = $"    private static readonly int {fieldName} = {call};\n";
+
+		await VerifyCSharpFixAsync(Source(call, call), Source(fieldName, fieldName, field));
+	}
+
+	[Fact]
+	public async Task RepeatedGroupsWithConflictingNames()
+	{
+		var first = "Shader.PropertyToID(\"_Main-Tex\") + Shader.PropertyToID(\"_Main Tex\")";
+		var test = Source(first, first);
+		const string fields =
+			"    private static readonly int MainTexId1 = Shader.PropertyToID(\"_Main Tex\");\n" +
+			"    private static readonly int MainTexId = Shader.PropertyToID(\"_Main-Tex\");\n";
+		var fixedTest = Source("MainTexId + MainTexId1", "MainTexId + MainTexId1", fields);
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task ReuseFieldFromAnotherPartialDeclaration()
+	{
+		const string otherPart = @"
+partial class Example
+{
+    private static readonly int ExistingColor = Shader.PropertyToID(""_Color"");
+}";
+		var test = Source(ColorCall, ColorCall, declaration: "partial class Example : MonoBehaviour") + otherPart;
+		var fixedTest = Source("ExistingColor", "ExistingColor", declaration: "partial class Example : MonoBehaviour") + otherPart;
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Fact]
+	public async Task CallsInOneMethod()
+	{
+		var test = Source(ColorCall + " + " + ColorCall, "0");
+		var diagnostic = ExpectDiagnostic().WithLocation(8, 16).WithArguments("_Color");
+
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+		await VerifyCSharpFixAsync(test, Source("ColorId + ColorId", "0", ColorField));
+	}
+
+	[Fact]
+	public async Task PreservesComments()
+	{
+		var test = Source("Shader.PropertyToID(/* property */ \"_Color\") /* first */", ColorCall + " /* second */");
+		var fixedTest = Source("/* property */ ColorId /* first */", "ColorId /* second */", ColorField);
+
+		await VerifyCSharpFixAsync(test, fixedTest);
+	}
+
+	[Theory]
+	[InlineData("Shader.PropertyToID(\"_Color\")", "0")]
+	[InlineData("Shader.PropertyToID(\"_Color\")", "Shader.PropertyToID(\"_Other\")")]
+	[InlineData("Shader.PropertyToID(\"_Color\")", "Shader.PropertyToID(\"_color\")")]
+	[InlineData("Shader.PropertyToID(null)", "Shader.PropertyToID(null)")]
+	[InlineData("Shader.PropertyToID(PropertyName)", "Shader.PropertyToID(PropertyName)", "    private string PropertyName = \"_Color\";\n")]
+	[InlineData("Shader.PropertyToID(\"_Color\")", "ColorId", ColorField)]
+	[InlineData("ColorId", "OtherColorId", ColorField + "    private static readonly int OtherColorId = Shader.PropertyToID(\"_Color\");\n")]
+	public async Task NoRepeatedLiteralCalls(string first, string second, string members = "")
+	{
+		await VerifyCSharpDiagnosticAsync(Source(first, second, members));
+	}
+
+	[Fact]
+	public async Task SingleCallInUpdateDoesNotCountAsRepeated()
+	{
+		const string test = @"
+using UnityEngine;
+
+class Example : MonoBehaviour
+{
+    void Update()
+    {
+        Debug.Log(Shader.PropertyToID(""_Color""));
+    }
+}";
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Theory]
+	[InlineData("Shader.PropertyToID(\"_Color\"); Shader.PropertyToID(\"_Color\");")]
+	[InlineData("System.Action action = () => Shader.PropertyToID(\"_Color\"); action();")]
+	[InlineData("for (Shader.PropertyToID(\"_Color\"); System.Environment.TickCount < 0; Shader.PropertyToID(\"_Color\")) { }")]
+	public async Task DiscardedValues(string statement)
+	{
+		var test = Source("0", ColorCall, firstSetup: "        " + statement + "\n");
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task ExpressionBodiedVoidMethod()
+	{
+		var test = Source("0", ColorCall, "    void Method() => Shader.PropertyToID(\"_Color\");\n");
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task UnrelatedMethod()
+	{
+		const string otherType = @"
+static class OtherShader
+{
+    public static int PropertyToID(string name) => 0;
+}";
+		var test = Source("OtherShader.PropertyToID(\"_Color\")", "OtherShader.PropertyToID(\"_Color\")") + otherType;
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task NestedTypesAreIndependent()
+	{
+		const string nested = @"    class Nested
+    {
+        int Read() => Shader.PropertyToID(""_Color"");
+    }
+";
+		await VerifyCSharpDiagnosticAsync(Source(ColorCall, "0", nested));
+	}
+
+	[Fact]
+	public async Task PartialDeclarationsAreIndependent()
+	{
+		const string otherPart = @"
+partial class Example
+{
+    int Read() => Shader.PropertyToID(""_Color"");
+}";
+		var test = Source(ColorCall, "0", declaration: "partial class Example : MonoBehaviour") + otherPart;
+
+		await VerifyCSharpDiagnosticAsync(test);
+	}
+
+	[Fact]
+	public async Task PropertyInitializersAreExcluded()
+	{
+		const string properties =
+			"    int ColorId { get; } = Shader.PropertyToID(\"_Color\");\n" +
+			"    int OtherColorId { get; } = Shader.PropertyToID(\"_Color\");\n";
+		await VerifyCSharpDiagnosticAsync(Source("ColorId", "OtherColorId", properties));
+	}
+
+	[Fact]
+	public void NoIndependentBatchFieldGeneration()
+	{
+		Assert.Null(new ShaderPropertyToIDCodeFix().GetFixAllProvider());
+	}
+
+	private static string Source(string first, string second, string members = "", string declaration = "class Example : MonoBehaviour",
+		string extraUsing = "", string methodModifier = "", string firstSetup = "")
+	{
+		if (members.Length > 0)
+			members += "\n";
+
+		return $@"
+using UnityEngine;
+{extraUsing}
+{declaration}
+{{
+{members}    {methodModifier}int First()
+    {{
+{firstSetup}        return {first};
+    }}
+
+    {methodModifier}int Second()
+    {{
+        return {second};
+    }}
+}}
+";
+	}
+}

--- a/src/Microsoft.Unity.Analyzers.Tests/ShaderPropertyToIDTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/ShaderPropertyToIDTests.cs
@@ -19,15 +19,24 @@ public class ShaderPropertyToIDTests : BaseCodeFixVerifierTest<ShaderPropertyToI
 	[InlineData("Shader.PropertyToID(@\"_Color\")")]
 	[InlineData("UnityEngine.Shader.PropertyToID(\"_Color\")")]
 	[InlineData("global::UnityEngine.Shader.PropertyToID(\"_Color\")")]
-	public async Task RepeatedLiteralCalls(string expression)
+	public async Task LiteralCall(string expression)
 	{
-		var test = Source(expression, ColorCall);
+		var test = Source(expression, "0");
 		var diagnostic = ExpectDiagnostic()
 			.WithLocation(8, 16)
 			.WithArguments("_Color");
 
 		await VerifyCSharpDiagnosticAsync(test, diagnostic);
-		await VerifyCSharpFixAsync(test, Source("ColorId", "ColorId", ColorField));
+		await VerifyCSharpFixAsync(test, Source("ColorId", "0", ColorField));
+	}
+
+	[Fact]
+	public async Task FixOnlySelectedCall()
+	{
+		await VerifyCSharpFixAsync(
+			Source(ColorCall, ColorCall),
+			Source("ColorId", ColorCall, ColorField),
+			codeFixIndex: 0);
 	}
 
 	[Theory]
@@ -127,7 +136,7 @@ public class ShaderPropertyToIDTests : BaseCodeFixVerifierTest<ShaderPropertyToI
 	}
 
 	[Fact]
-	public async Task RepeatedGroupsWithConflictingNames()
+	public async Task DifferentNamesWithTheSameFieldName()
 	{
 		var first = "Shader.PropertyToID(\"_Main-Tex\") + Shader.PropertyToID(\"_Main Tex\")";
 		var test = Source(first, first);
@@ -157,10 +166,26 @@ partial class Example
 	public async Task CallsInOneMethod()
 	{
 		var test = Source(ColorCall + " + " + ColorCall, "0");
-		var diagnostic = ExpectDiagnostic().WithLocation(8, 16).WithArguments("_Color");
+		var first = ExpectDiagnostic().WithLocation(8, 16).WithArguments("_Color");
+		var second = ExpectDiagnostic().WithLocation(8, 16 + ColorCall.Length + 3).WithArguments("_Color");
 
-		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+		await VerifyCSharpDiagnosticAsync(test, first, second);
 		await VerifyCSharpFixAsync(test, Source("ColorId + ColorId", "0", ColorField));
+	}
+
+	[Theory]
+	[InlineData("_Other", "OtherId")]
+	[InlineData("_color", "ColorId1")]
+	public async Task DifferentPropertyNames(string name, string fieldName)
+	{
+		var call = $"Shader.PropertyToID(\"{name}\")";
+		var test = Source(ColorCall, call);
+		var first = ExpectDiagnostic().WithLocation(8, 16).WithArguments("_Color");
+		var second = ExpectDiagnostic().WithLocation(13, 16).WithArguments(name);
+		var field = $"    private static readonly int {fieldName} = {call};\n";
+
+		await VerifyCSharpDiagnosticAsync(test, first, second);
+		await VerifyCSharpFixAsync(test, Source("ColorId", fieldName, field + ColorField));
 	}
 
 	[Fact]
@@ -173,20 +198,17 @@ partial class Example
 	}
 
 	[Theory]
-	[InlineData("Shader.PropertyToID(\"_Color\")", "0")]
-	[InlineData("Shader.PropertyToID(\"_Color\")", "Shader.PropertyToID(\"_Other\")")]
-	[InlineData("Shader.PropertyToID(\"_Color\")", "Shader.PropertyToID(\"_color\")")]
 	[InlineData("Shader.PropertyToID(null)", "Shader.PropertyToID(null)")]
 	[InlineData("Shader.PropertyToID(PropertyName)", "Shader.PropertyToID(PropertyName)", "    private string PropertyName = \"_Color\";\n")]
-	[InlineData("Shader.PropertyToID(\"_Color\")", "ColorId", ColorField)]
+	[InlineData("ColorId", "0", ColorField)]
 	[InlineData("ColorId", "OtherColorId", ColorField + "    private static readonly int OtherColorId = Shader.PropertyToID(\"_Color\");\n")]
-	public async Task NoRepeatedLiteralCalls(string first, string second, string members = "")
+	public async Task NonLiteralOrCachedCalls(string first, string second, string members = "")
 	{
 		await VerifyCSharpDiagnosticAsync(Source(first, second, members));
 	}
 
 	[Fact]
-	public async Task SingleCallInUpdateDoesNotCountAsRepeated()
+	public async Task SingleCallInUpdate()
 	{
 		const string test = @"
 using UnityEngine;
@@ -199,7 +221,23 @@ class Example : MonoBehaviour
     }
 }";
 
-		await VerifyCSharpDiagnosticAsync(test);
+		var diagnostic = ExpectDiagnostic().WithLocation(8, 19).WithArguments("_Color");
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+
+class Example : MonoBehaviour
+{
+    private static readonly int ColorId = Shader.PropertyToID(""_Color"");
+
+    void Update()
+    {
+        Debug.Log(ColorId);
+    }
+}";
+
+		await VerifyCSharpFixAsync(test, fixedTest);
 	}
 
 	[Theory]
@@ -208,14 +246,14 @@ class Example : MonoBehaviour
 	[InlineData("for (Shader.PropertyToID(\"_Color\"); System.Environment.TickCount < 0; Shader.PropertyToID(\"_Color\")) { }")]
 	public async Task DiscardedValues(string statement)
 	{
-		var test = Source("0", ColorCall, firstSetup: "        " + statement + "\n");
+		var test = Source("0", "0", firstSetup: "        " + statement + "\n");
 		await VerifyCSharpDiagnosticAsync(test);
 	}
 
 	[Fact]
 	public async Task ExpressionBodiedVoidMethod()
 	{
-		var test = Source("0", ColorCall, "    void Method() => Shader.PropertyToID(\"_Color\");\n");
+		var test = Source("0", "0", "    void Method() => Shader.PropertyToID(\"_Color\");\n");
 		await VerifyCSharpDiagnosticAsync(test);
 	}
 
@@ -233,18 +271,39 @@ static class OtherShader
 	}
 
 	[Fact]
-	public async Task NestedTypesAreIndependent()
+	public async Task SingleCallInNestedType()
 	{
-		const string nested = @"    class Nested
+		const string test = @"
+using UnityEngine;
+
+class Example
+{
+    class Nested
     {
         int Read() => Shader.PropertyToID(""_Color"");
     }
-";
-		await VerifyCSharpDiagnosticAsync(Source(ColorCall, "0", nested));
+}";
+		var diagnostic = ExpectDiagnostic().WithLocation(8, 23).WithArguments("_Color");
+		await VerifyCSharpDiagnosticAsync(test, diagnostic);
+
+		const string fixedTest = @"
+using UnityEngine;
+
+class Example
+{
+    class Nested
+    {
+        private static readonly int ColorId = Shader.PropertyToID(""_Color"");
+
+        int Read() => ColorId;
+    }
+}";
+
+		await VerifyCSharpFixAsync(test, fixedTest);
 	}
 
 	[Fact]
-	public async Task PartialDeclarationsAreIndependent()
+	public async Task CallsInDifferentPartialDeclarations()
 	{
 		const string otherPart = @"
 partial class Example
@@ -253,7 +312,9 @@ partial class Example
 }";
 		var test = Source(ColorCall, "0", declaration: "partial class Example : MonoBehaviour") + otherPart;
 
-		await VerifyCSharpDiagnosticAsync(test);
+		var fixedTest = Source("ColorId", "0", ColorField, declaration: "partial class Example : MonoBehaviour")
+			+ otherPart.Replace(ColorCall, "ColorId");
+		await VerifyCSharpFixAsync(test, fixedTest);
 	}
 
 	[Fact]

--- a/src/Microsoft.Unity.Analyzers/AnimatorStringToHash.cs
+++ b/src/Microsoft.Unity.Analyzers/AnimatorStringToHash.cs
@@ -3,10 +3,8 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *-------------------------------------------------------------------------------------------*/
 
-using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -142,74 +140,25 @@ public class AnimatorStringToHashCodeFix : CodeFixProvider
 		if (classDecl == null)
 			return document;
 
-		var fieldName = GenerateFieldName(literalValue);
-
-		var fieldExists = classDecl.Members
-			.OfType<FieldDeclarationSyntax>()
-			.SelectMany(f => f.Declaration.Variables)
-			.Any(v => v.Identifier.Text == fieldName);
+		var factory = methodSymbol.ContainingType.GetMembers("StringToHash")
+			.OfType<IMethodSymbol>()
+			.FirstOrDefault(m => m.IsStatic && m.Parameters.Length == 1
+				&& m.Parameters[0].Type.SpecialType == SpecialType.System_String
+				&& m.ReturnType.SpecialType == SpecialType.System_Int32);
+		if (factory == null)
+			return document;
 
 		var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-
-		if (!fieldExists)
-		{
-			// Create: private static readonly int FieldName = Animator.StringToHash("value");
-			var hashInvocation = SyntaxFactory.InvocationExpression(
-					SyntaxFactory.MemberAccessExpression(
-						SyntaxKind.SimpleMemberAccessExpression,
-						SyntaxFactory.IdentifierName(nameof(UnityEngine.Animator)),
-						SyntaxFactory.IdentifierName("StringToHash")))
-				.WithArgumentList(SyntaxFactory.ArgumentList(
-					SyntaxFactory.SingletonSeparatedList(
-						SyntaxFactory.Argument(
-							SyntaxFactory.LiteralExpression(
-								SyntaxKind.StringLiteralExpression,
-								SyntaxFactory.Literal(literalValue))))));
-
-			var fieldDecl = SyntaxFactory.FieldDeclaration(
-					SyntaxFactory.VariableDeclaration(
-						SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)),
-						SyntaxFactory.SeparatedList([
-							SyntaxFactory.VariableDeclarator(
-								SyntaxFactory.Identifier(fieldName),
-								null,
-								SyntaxFactory.EqualsValueClause(hashInvocation))
-						])))
-				.AddModifiers(
-					SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
-					SyntaxFactory.Token(SyntaxKind.StaticKeyword),
-					SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
-
-			editor.InsertMembers(classDecl, 0, [fieldDecl]);
-		}
+		var fieldName = CachedStringIdField.GetOrCreate(editor, classDecl, factory, literalValue, "Hash",
+			[stringArgument.Expression], cancellationToken);
+		if (fieldName == null)
+			return document;
 
 		var newArgument = stringArgument
-			.WithExpression(SyntaxFactory.IdentifierName(fieldName))
-			.WithTrailingTrivia(stringArgument.GetTrailingTrivia());
+			.WithExpression(SyntaxFactory.IdentifierName(fieldName).WithTriviaFrom(stringArgument.Expression));
 
 		editor.ReplaceNode(stringArgument, newArgument);
 
 		return editor.GetChangedDocument();
-	}
-
-	private static string GenerateFieldName(string literalValue)
-	{
-		var cleaned = Regex.Replace(literalValue, @"[^a-zA-Z0-9]", " ");
-
-		var words = cleaned.Split([' '], StringSplitOptions.RemoveEmptyEntries);
-		var pascalCase = string.Concat(words.Select(ToPascalCaseWord));
-
-		if (!string.IsNullOrEmpty(pascalCase) && char.IsDigit(pascalCase[0]))
-			pascalCase = "_" + pascalCase;
-
-		return pascalCase + "Hash";
-	}
-
-	private static string ToPascalCaseWord(string word)
-	{
-		if (string.IsNullOrEmpty(word))
-			return "";
-
-		return char.ToUpperInvariant(word[0]) + word.Substring(1);
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/AnimatorStringToHash.cs
+++ b/src/Microsoft.Unity.Analyzers/AnimatorStringToHash.cs
@@ -150,7 +150,7 @@ public class AnimatorStringToHashCodeFix : CodeFixProvider
 
 		var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 		var fieldName = CachedStringIdField.GetOrCreate(editor, classDecl, factory, literalValue, "Hash",
-			[stringArgument.Expression], cancellationToken);
+			stringArgument.Expression, cancellationToken);
 		if (fieldName == null)
 			return document;
 

--- a/src/Microsoft.Unity.Analyzers/CachedStringIdField.cs
+++ b/src/Microsoft.Unity.Analyzers/CachedStringIdField.cs
@@ -4,7 +4,6 @@
  *-------------------------------------------------------------------------------------------*/
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -20,7 +19,7 @@ namespace Microsoft.Unity.Analyzers;
 internal static class CachedStringIdField
 {
 	public static string? GetOrCreate(DocumentEditor editor, TypeDeclarationSyntax declaration,
-		IMethodSymbol factory, string value, string suffix, IReadOnlyList<ExpressionSyntax> usages, CancellationToken cancellationToken)
+		IMethodSymbol factory, string value, string suffix, ExpressionSyntax usage, CancellationToken cancellationToken)
 	{
 		var model = editor.SemanticModel;
 		if (model.GetDeclaredSymbol(declaration, cancellationToken) is not INamedTypeSymbol type)
@@ -47,7 +46,7 @@ internal static class CachedStringIdField
 				if (SymbolEqualityComparer.Default.Equals(fieldModel.GetSymbolInfo(initializer, cancellationToken).Symbol, factory)
 					&& fieldModel.GetConstantValue(initializer.ArgumentList.Arguments[0].Expression, cancellationToken).Value is string existingValue
 					&& existingValue == value
-					&& CanReference(model, usages, field.Name, field))
+					&& CanReference(model, usage, field.Name, field))
 					return field.Name;
 			}
 		}
@@ -55,7 +54,7 @@ internal static class CachedStringIdField
 		var baseName = GenerateFieldName(value, suffix);
 		var fieldName = baseName;
 		var counter = 1;
-		while (fieldName == type.Name || type.GetMembers(fieldName).Length > 0 || !CanReference(model, usages, fieldName))
+		while (fieldName == type.Name || type.GetMembers(fieldName).Length > 0 || !CanReference(model, usage, fieldName))
 			fieldName = baseName + counter++;
 
 		ExpressionSyntax factoryExpression = IdentifierName(factory.Name);
@@ -83,17 +82,11 @@ internal static class CachedStringIdField
 		return fieldName;
 	}
 
-	private static bool CanReference(SemanticModel model, IReadOnlyList<ExpressionSyntax> usages, string name, IFieldSymbol? existingField = null)
+	private static bool CanReference(SemanticModel model, ExpressionSyntax usage, string name, IFieldSymbol? existingField = null)
 	{
-		foreach (var usage in usages)
-		{
-			var symbols = model.LookupSymbols(usage.SpanStart, name: name);
-			if (existingField == null ? symbols.Length != 0
-				: symbols.Length != 1 || !SymbolEqualityComparer.Default.Equals(symbols[0], existingField))
-				return false;
-		}
-
-		return true;
+		var symbols = model.LookupSymbols(usage.SpanStart, name: name);
+		return existingField == null ? symbols.Length == 0
+			: symbols.Length == 1 && SymbolEqualityComparer.Default.Equals(symbols[0], existingField);
 	}
 
 	private static string GenerateFieldName(string value, string suffix)

--- a/src/Microsoft.Unity.Analyzers/CachedStringIdField.cs
+++ b/src/Microsoft.Unity.Analyzers/CachedStringIdField.cs
@@ -1,0 +1,110 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Simplification;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Unity.Analyzers;
+
+internal static class CachedStringIdField
+{
+	public static string? GetOrCreate(DocumentEditor editor, TypeDeclarationSyntax declaration,
+		IMethodSymbol factory, string value, string suffix, IReadOnlyList<ExpressionSyntax> usages, CancellationToken cancellationToken)
+	{
+		var model = editor.SemanticModel;
+		if (model.GetDeclaredSymbol(declaration, cancellationToken) is not INamedTypeSymbol type)
+			return null;
+
+		foreach (var field in type.GetMembers().OfType<IFieldSymbol>())
+		{
+			if (!field.IsStatic || !field.IsReadOnly || field.Type.SpecialType != SpecialType.System_Int32)
+				continue;
+
+			foreach (var reference in field.DeclaringSyntaxReferences)
+			{
+				if (reference.GetSyntax(cancellationToken) is not VariableDeclaratorSyntax
+					{
+						Initializer.Value: InvocationExpressionSyntax initializer
+					}
+					|| initializer.ArgumentList.Arguments.Count != 1)
+					continue;
+
+				var fieldModel = initializer.SyntaxTree == model.SyntaxTree
+					? model
+					: model.Compilation.GetSemanticModel(initializer.SyntaxTree);
+
+				if (SymbolEqualityComparer.Default.Equals(fieldModel.GetSymbolInfo(initializer, cancellationToken).Symbol, factory)
+					&& fieldModel.GetConstantValue(initializer.ArgumentList.Arguments[0].Expression, cancellationToken).Value is string existingValue
+					&& existingValue == value
+					&& CanReference(model, usages, field.Name, field))
+					return field.Name;
+			}
+		}
+
+		var baseName = GenerateFieldName(value, suffix);
+		var fieldName = baseName;
+		var counter = 1;
+		while (fieldName == type.Name || type.GetMembers(fieldName).Length > 0 || !CanReference(model, usages, fieldName))
+			fieldName = baseName + counter++;
+
+		ExpressionSyntax factoryExpression = IdentifierName(factory.Name);
+		var visibleFactories = model.LookupSymbols(declaration.OpenBraceToken.Span.End, name: factory.Name);
+		if (visibleFactories.Length != 1 || !SymbolEqualityComparer.Default.Equals(visibleFactories[0], factory))
+		{
+			var factoryType = ParseName(factory.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
+				.WithAdditionalAnnotations(Simplifier.Annotation);
+			factoryExpression = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, factoryType, IdentifierName(factory.Name));
+		}
+
+		var initializerExpression = InvocationExpression(
+			factoryExpression,
+			ArgumentList(SingletonSeparatedList(Argument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(value))))));
+
+		var fieldDeclaration = FieldDeclaration(
+				VariableDeclaration(
+					PredefinedType(Token(SyntaxKind.IntKeyword)),
+					SingletonSeparatedList(
+						VariableDeclarator(Identifier(fieldName))
+							.WithInitializer(EqualsValueClause(initializerExpression)))))
+			.AddModifiers(Token(SyntaxKind.PrivateKeyword), Token(SyntaxKind.StaticKeyword), Token(SyntaxKind.ReadOnlyKeyword));
+
+		editor.InsertMembers(declaration, 0, [fieldDeclaration]);
+		return fieldName;
+	}
+
+	private static bool CanReference(SemanticModel model, IReadOnlyList<ExpressionSyntax> usages, string name, IFieldSymbol? existingField = null)
+	{
+		foreach (var usage in usages)
+		{
+			var symbols = model.LookupSymbols(usage.SpanStart, name: name);
+			if (existingField == null ? symbols.Length != 0
+				: symbols.Length != 1 || !SymbolEqualityComparer.Default.Equals(symbols[0], existingField))
+				return false;
+		}
+
+		return true;
+	}
+
+	private static string GenerateFieldName(string value, string suffix)
+	{
+		var cleaned = Regex.Replace(value, @"[^a-zA-Z0-9]", " ");
+		var words = cleaned.Split([' '], StringSplitOptions.RemoveEmptyEntries);
+		var name = string.Concat(words.Select(word => char.ToUpperInvariant(word[0]) + word.Substring(1)));
+
+		if (name.Length > 0 && char.IsDigit(name[0]))
+			name = "_" + name;
+
+		return name + suffix;
+	}
+}

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -1285,7 +1285,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Cache repeated Shader.PropertyToID calls with the same string literal in a static readonly field..
+        ///   Looks up a localized string similar to Cache the result of Shader.PropertyToID in a static readonly field to avoid recomputing the ID..
         /// </summary>
         internal static string ShaderPropertyToIDDiagnosticDescription {
             get {
@@ -1303,7 +1303,7 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Cache repeated Shader.PropertyToID calls.
+        ///   Looks up a localized string similar to Cache Shader.PropertyToID calls.
         /// </summary>
         internal static string ShaderPropertyToIDDiagnosticTitle {
             get {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.Designer.cs
@@ -1276,6 +1276,42 @@ namespace Microsoft.Unity.Analyzers.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cache shader property ID.
+        /// </summary>
+        internal static string ShaderPropertyToIDCodeFixTitle {
+            get {
+                return ResourceManager.GetString("ShaderPropertyToIDCodeFixTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cache repeated Shader.PropertyToID calls with the same string literal in a static readonly field..
+        /// </summary>
+        internal static string ShaderPropertyToIDDiagnosticDescription {
+            get {
+                return ResourceManager.GetString("ShaderPropertyToIDDiagnosticDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cache the shader property ID for &apos;{0}&apos; instead of calling Shader.PropertyToID repeatedly..
+        /// </summary>
+        internal static string ShaderPropertyToIDDiagnosticMessageFormat {
+            get {
+                return ResourceManager.GetString("ShaderPropertyToIDDiagnosticMessageFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cache repeated Shader.PropertyToID calls.
+        /// </summary>
+        internal static string ShaderPropertyToIDDiagnosticTitle {
+            get {
+                return ResourceManager.GetString("ShaderPropertyToIDDiagnosticTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Use CompareTag method.
         /// </summary>
         internal static string TagComparisonCodeFixTitle {

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -716,12 +716,12 @@
     <value>Cache shader property ID</value>
   </data>
   <data name="ShaderPropertyToIDDiagnosticDescription" xml:space="preserve">
-    <value>Cache repeated Shader.PropertyToID calls with the same string literal in a static readonly field.</value>
+    <value>Cache the result of Shader.PropertyToID in a static readonly field to avoid recomputing the ID.</value>
   </data>
   <data name="ShaderPropertyToIDDiagnosticMessageFormat" xml:space="preserve">
     <value>Cache the shader property ID for '{0}' instead of calling Shader.PropertyToID repeatedly.</value>
   </data>
   <data name="ShaderPropertyToIDDiagnosticTitle" xml:space="preserve">
-    <value>Cache repeated Shader.PropertyToID calls</value>
+    <value>Cache Shader.PropertyToID calls</value>
   </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
+++ b/src/Microsoft.Unity.Analyzers/Resources/Strings.resx
@@ -712,4 +712,16 @@
   <data name="NonAllocatingArrayAccessDiagnosticTitle" xml:space="preserve">
     <value>Use non-allocating array access</value>
   </data>
+  <data name="ShaderPropertyToIDCodeFixTitle" xml:space="preserve">
+    <value>Cache shader property ID</value>
+  </data>
+  <data name="ShaderPropertyToIDDiagnosticDescription" xml:space="preserve">
+    <value>Cache repeated Shader.PropertyToID calls with the same string literal in a static readonly field.</value>
+  </data>
+  <data name="ShaderPropertyToIDDiagnosticMessageFormat" xml:space="preserve">
+    <value>Cache the shader property ID for '{0}' instead of calling Shader.PropertyToID repeatedly.</value>
+  </data>
+  <data name="ShaderPropertyToIDDiagnosticTitle" xml:space="preserve">
+    <value>Cache repeated Shader.PropertyToID calls</value>
+  </data>
 </root>

--- a/src/Microsoft.Unity.Analyzers/ShaderPropertyToID.cs
+++ b/src/Microsoft.Unity.Analyzers/ShaderPropertyToID.cs
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *-------------------------------------------------------------------------------------------*/
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -44,84 +42,47 @@ public class ShaderPropertyToIDAnalyzer : DiagnosticAnalyzer
 	{
 		context.EnableConcurrentExecution();
 		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-		context.RegisterSyntaxNodeAction(AnalyzeType, SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.RecordDeclaration);
+		context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
 	}
 
-	private static void AnalyzeType(SyntaxNodeAnalysisContext context)
+	private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
 	{
-		var groups = CollectCalls((TypeDeclarationSyntax)context.Node, context.SemanticModel, context.CancellationToken);
-		if (groups == null)
+		var invocation = (InvocationExpressionSyntax)context.Node;
+		var name = invocation.Expression switch
+		{
+			MemberAccessExpressionSyntax access => access.Name.Identifier.ValueText,
+			IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+			_ => null
+		};
+
+		if (name != "PropertyToID" || invocation.ArgumentList.Arguments.Count != 1
+			|| invocation.ArgumentList.Arguments[0].Expression is not LiteralExpressionSyntax literal
+			|| !literal.IsKind(SyntaxKind.StringLiteralExpression)
+			|| invocation.ContainsDirectives)
 			return;
 
-		foreach (var group in groups)
+		for (var parent = invocation.Parent; parent != null; parent = parent.Parent)
 		{
-			if (group.Value.Count >= 2)
-				context.ReportDiagnostic(Diagnostic.Create(Rule, group.Value[0].GetLocation(), group.Key));
-		}
-	}
+			// Initializers already cache the computed ID.
+			if (parent is BaseFieldDeclarationSyntax or EqualsValueClauseSyntax { Parent: PropertyDeclarationSyntax })
+				return;
 
-	internal static Dictionary<string, List<InvocationExpressionSyntax>>? CollectCalls(
-		TypeDeclarationSyntax declaration, SemanticModel model, CancellationToken cancellationToken)
-	{
-		List<InvocationExpressionSyntax>? candidates = null;
-		foreach (var member in declaration.Members)
-		{
-			cancellationToken.ThrowIfCancellationRequested();
-			if (member is BaseTypeDeclarationSyntax or BaseFieldDeclarationSyntax)
-				continue;
-
-			foreach (var node in member.DescendantNodes(ShouldDescend))
-			{
-				if (node is not InvocationExpressionSyntax invocation || invocation.ArgumentList.Arguments.Count != 1
-					|| invocation.ContainsDirectives)
-					continue;
-
-				var name = invocation.Expression switch
-				{
-					MemberAccessExpressionSyntax access => access.Name.Identifier.ValueText,
-					IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
-					_ => null
-				};
-
-				if (name == "PropertyToID"
-					&& invocation.ArgumentList.Arguments[0].Expression is LiteralExpressionSyntax literal
-					&& literal.IsKind(SyntaxKind.StringLiteralExpression))
-					(candidates ??= []).Add(invocation);
-			}
+			if (parent is MemberDeclarationSyntax)
+				break;
 		}
 
-		if (candidates == null || candidates.Count < 2)
-			return null;
+		if (context.SemanticModel.GetOperation(invocation, context.CancellationToken) is not IInvocationOperation operation
+			|| operation.Parent is IExpressionStatementOperation)
+			return;
 
-		Dictionary<string, List<InvocationExpressionSyntax>>? groups = null;
-		foreach (var candidate in candidates)
-		{
-			cancellationToken.ThrowIfCancellationRequested();
-			if (model.GetOperation(candidate, cancellationToken) is not IInvocationOperation operation
-				|| operation.Parent is IExpressionStatementOperation
-				|| operation.Arguments.Length != 1
-				|| operation.Arguments[0].Value.ConstantValue.Value is not string value)
-				continue;
+		var method = operation.TargetMethod;
+		if (!method.IsStatic || !method.ContainingType.Matches(typeof(UnityEngine.Shader))
+			|| method.Parameters.Length != 1
+			|| method.Parameters[0].Type.SpecialType != SpecialType.System_String
+			|| method.ReturnType.SpecialType != SpecialType.System_Int32)
+			return;
 
-			var method = operation.TargetMethod;
-			if (!method.IsStatic || !method.ContainingType.Matches(typeof(UnityEngine.Shader))
-				|| method.Name != "PropertyToID" || method.Parameters.Length != 1
-				|| method.Parameters[0].Type.SpecialType != SpecialType.System_String
-				|| method.ReturnType.SpecialType != SpecialType.System_Int32)
-				continue;
-
-			groups ??= new(StringComparer.Ordinal);
-			if (!groups.TryGetValue(value, out var calls))
-				groups.Add(value, calls = []);
-			calls.Add(candidate);
-		}
-
-		return groups;
-	}
-
-	private static bool ShouldDescend(SyntaxNode node)
-	{
-		return node is not EqualsValueClauseSyntax { Parent: PropertyDeclarationSyntax };
+		context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), literal.Token.ValueText));
 	}
 }
 
@@ -154,33 +115,21 @@ public class ShaderPropertyToIDCodeFix : CodeFixProvider
 		if (declaration == null || model?.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol factory)
 			return document;
 
-		var groups = ShaderPropertyToIDAnalyzer.CollectCalls(declaration, model, cancellationToken);
-		if (groups == null)
+		if (invocation.ArgumentList.Arguments[0].Expression is not LiteralExpressionSyntax literal)
 			return document;
 
-		foreach (var group in groups)
-		{
-			if (group.Value.Count < 2 || !group.Value.Contains(invocation))
-				continue;
+		var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+		var fieldName = CachedStringIdField.GetOrCreate(editor, declaration, factory, literal.Token.ValueText, "Id", invocation, cancellationToken);
+		if (fieldName == null)
+			return document;
 
-			var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-			var fieldName = CachedStringIdField.GetOrCreate(editor, declaration, factory, group.Key, "Id", group.Value, cancellationToken);
-			if (fieldName == null)
-				return document;
+		var interiorTrivia = invocation.DescendantTrivia().Where(trivia => invocation.Span.Contains(trivia.Span));
+		var reference = IdentifierName(fieldName)
+			.WithTriviaFrom(invocation)
+			.WithLeadingTrivia(invocation.GetLeadingTrivia().AddRange(interiorTrivia))
+			.WithAdditionalAnnotations(Formatter.Annotation);
+		editor.ReplaceNode(invocation, reference);
 
-			foreach (var call in group.Value)
-			{
-				var interiorTrivia = call.DescendantTrivia().Where(trivia => call.Span.Contains(trivia.Span));
-				var reference = IdentifierName(fieldName)
-					.WithTriviaFrom(call)
-					.WithLeadingTrivia(call.GetLeadingTrivia().AddRange(interiorTrivia))
-					.WithAdditionalAnnotations(Formatter.Annotation);
-				editor.ReplaceNode(call, reference);
-			}
-
-			return editor.GetChangedDocument();
-		}
-
-		return document;
+		return editor.GetChangedDocument();
 	}
 }

--- a/src/Microsoft.Unity.Analyzers/ShaderPropertyToID.cs
+++ b/src/Microsoft.Unity.Analyzers/ShaderPropertyToID.cs
@@ -1,0 +1,186 @@
+/*--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *-------------------------------------------------------------------------------------------*/
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.Unity.Analyzers.Resources;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Unity.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ShaderPropertyToIDAnalyzer : DiagnosticAnalyzer
+{
+	private const string RuleId = "UNT0046";
+
+	internal static readonly DiagnosticDescriptor Rule = new(
+		id: RuleId,
+		title: Strings.ShaderPropertyToIDDiagnosticTitle,
+		messageFormat: Strings.ShaderPropertyToIDDiagnosticMessageFormat,
+		category: DiagnosticCategory.Performance,
+		defaultSeverity: DiagnosticSeverity.Info,
+		isEnabledByDefault: true,
+		helpLinkUri: HelpLink.ForDiagnosticId(RuleId),
+		description: Strings.ShaderPropertyToIDDiagnosticDescription);
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+	public override void Initialize(AnalysisContext context)
+	{
+		context.EnableConcurrentExecution();
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+		context.RegisterSyntaxNodeAction(AnalyzeType, SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.RecordDeclaration);
+	}
+
+	private static void AnalyzeType(SyntaxNodeAnalysisContext context)
+	{
+		var groups = CollectCalls((TypeDeclarationSyntax)context.Node, context.SemanticModel, context.CancellationToken);
+		if (groups == null)
+			return;
+
+		foreach (var group in groups)
+		{
+			if (group.Value.Count >= 2)
+				context.ReportDiagnostic(Diagnostic.Create(Rule, group.Value[0].GetLocation(), group.Key));
+		}
+	}
+
+	internal static Dictionary<string, List<InvocationExpressionSyntax>>? CollectCalls(
+		TypeDeclarationSyntax declaration, SemanticModel model, CancellationToken cancellationToken)
+	{
+		List<InvocationExpressionSyntax>? candidates = null;
+		foreach (var member in declaration.Members)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (member is BaseTypeDeclarationSyntax or BaseFieldDeclarationSyntax)
+				continue;
+
+			foreach (var node in member.DescendantNodes(ShouldDescend))
+			{
+				if (node is not InvocationExpressionSyntax invocation || invocation.ArgumentList.Arguments.Count != 1
+					|| invocation.ContainsDirectives)
+					continue;
+
+				var name = invocation.Expression switch
+				{
+					MemberAccessExpressionSyntax access => access.Name.Identifier.ValueText,
+					IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+					_ => null
+				};
+
+				if (name == "PropertyToID"
+					&& invocation.ArgumentList.Arguments[0].Expression is LiteralExpressionSyntax literal
+					&& literal.IsKind(SyntaxKind.StringLiteralExpression))
+					(candidates ??= []).Add(invocation);
+			}
+		}
+
+		if (candidates == null || candidates.Count < 2)
+			return null;
+
+		Dictionary<string, List<InvocationExpressionSyntax>>? groups = null;
+		foreach (var candidate in candidates)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (model.GetOperation(candidate, cancellationToken) is not IInvocationOperation operation
+				|| operation.Parent is IExpressionStatementOperation
+				|| operation.Arguments.Length != 1
+				|| operation.Arguments[0].Value.ConstantValue.Value is not string value)
+				continue;
+
+			var method = operation.TargetMethod;
+			if (!method.IsStatic || !method.ContainingType.Matches(typeof(UnityEngine.Shader))
+				|| method.Name != "PropertyToID" || method.Parameters.Length != 1
+				|| method.Parameters[0].Type.SpecialType != SpecialType.System_String
+				|| method.ReturnType.SpecialType != SpecialType.System_Int32)
+				continue;
+
+			groups ??= new(StringComparer.Ordinal);
+			if (!groups.TryGetValue(value, out var calls))
+				groups.Add(value, calls = []);
+			calls.Add(candidate);
+		}
+
+		return groups;
+	}
+
+	private static bool ShouldDescend(SyntaxNode node)
+	{
+		return node is not EqualsValueClauseSyntax { Parent: PropertyDeclarationSyntax };
+	}
+}
+
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+public class ShaderPropertyToIDCodeFix : CodeFixProvider
+{
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ShaderPropertyToIDAnalyzer.Rule.Id);
+
+	// Independent batch actions cannot coordinate generated fields in the same type.
+	public sealed override FixAllProvider? GetFixAllProvider() => null;
+
+	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+	{
+		var invocation = await context.GetFixableNodeAsync<InvocationExpressionSyntax>();
+		if (invocation == null)
+			return;
+
+		context.RegisterCodeFix(
+			CodeAction.Create(
+				Strings.ShaderPropertyToIDCodeFixTitle,
+				ct => CachePropertyIdAsync(context.Document, invocation, ct),
+				ShaderPropertyToIDAnalyzer.Rule.Id),
+			context.Diagnostics);
+	}
+
+	private static async Task<Document> CachePropertyIdAsync(Document document, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
+	{
+		var declaration = invocation.FirstAncestorOrSelf<TypeDeclarationSyntax>();
+		var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+		if (declaration == null || model?.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol factory)
+			return document;
+
+		var groups = ShaderPropertyToIDAnalyzer.CollectCalls(declaration, model, cancellationToken);
+		if (groups == null)
+			return document;
+
+		foreach (var group in groups)
+		{
+			if (group.Value.Count < 2 || !group.Value.Contains(invocation))
+				continue;
+
+			var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+			var fieldName = CachedStringIdField.GetOrCreate(editor, declaration, factory, group.Key, "Id", group.Value, cancellationToken);
+			if (fieldName == null)
+				return document;
+
+			foreach (var call in group.Value)
+			{
+				var interiorTrivia = call.DescendantTrivia().Where(trivia => call.Span.Contains(trivia.Span));
+				var reference = IdentifierName(fieldName)
+					.WithTriviaFrom(call)
+					.WithLeadingTrivia(call.GetLeadingTrivia().AddRange(interiorTrivia))
+					.WithAdditionalAnnotations(Formatter.Annotation);
+				editor.ReplaceNode(call, reference);
+			}
+
+			return editor.GetChangedDocument();
+		}
+
+		return document;
+	}
+}


### PR DESCRIPTION
Fixes #495

#### Checklist
- [x] I have read the [Contribution Guide](https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/main/CONTRIBUTING.md).
- [x] There is a tracking issue describing the agreed new diagnostic: #495.
- [x] I have added tests that prove the feature works.
- [x] I have added the necessary documentation.

#### Short description of what this resolves:

Adds **UNT0046: Cache Shader.PropertyToID calls**, following UNT0041's per-call approach. A single literal `Shader.PropertyToID` call is reported, including a call appearing only once in `Update`: the script can execute that call repeatedly at runtime.

The fix replaces the selected call with a cached `static readonly int` field. Field generation is shared with the existing Animator fixer through `CachedStringIdField`; UNT0041 detection and documentation remain unchanged.

#### Changes proposed in this pull request:
- Analyze individual invocations with syntax-first filtering. There is no occurrence threshold, grouping, or type-body scan.
- Reuse or create a cached field for the selected literal property name, using the same field-generation helper as the Animator fixer.
- Leave already-cached field/property initializers and discarded results unchanged. Match string literals, as UNT0041 does.
- Cover single calls in Update, independent property names, existing fields, naming conflicts, and nested/partial declarations, alongside Animator regressions.
- Follow UNT0041's user-facing documentation structure: explanation, flagged examples, and the static readonly solution.

#### Validation
- Test project builds with no warnings or errors.
- All 70 tests in `ShaderPropertyToIDTests` and `AnimatorStringToHashTests` pass.
- Husky pre-commit formatting completed successfully.