### PR TITLE
Extend UNT0045 to Input.accelerationEvents

### DIFF
--- a/doc/UNT0045.md
+++ b/doc/UNT0045.md
@@ -1,11 +1,13 @@
 # UNT0045 Use non-allocating array access
 
-Reading `Collision.contacts`, `Collision2D.contacts`, or `Input.touches` can allocate an array. When only its length or a single element is needed, use the corresponding non-allocating API instead:
+Reading `Collision.contacts`, `Collision2D.contacts`, `Input.touches`, or `Input.accelerationEvents` can allocate an array. When only its length or a single element is needed, use the corresponding non-allocating API instead:
 
 - `Collision.contacts.Length` and `Collision2D.contacts.Length`: use `contactCount`.
 - `Collision.contacts[index]` and `Collision2D.contacts[index]`: use `GetContact(index)`.
 - `Input.touches.Length`: use `Input.touchCount`.
 - `Input.touches[index]`: use `Input.GetTouch(index)`.
+- `Input.accelerationEvents.Length`: use `Input.accelerationEventCount`.
+- `Input.accelerationEvents[index]`: use `Input.GetAccelerationEvent(index)`.
 
 This rule applies to the legacy `UnityEngine.Input` API, not the Input System package.
 
@@ -32,6 +34,9 @@ class Example : MonoBehaviour
     {
         if (Input.touches.Length > 0)
             Debug.Log(Input.touches[0].position);
+
+        if (Input.accelerationEvents.Length > 0)
+            Debug.Log(Input.accelerationEvents[0].acceleration);
     }
 }
 ```
@@ -59,6 +64,9 @@ class Example : MonoBehaviour
     {
         if (Input.touchCount > 0)
             Debug.Log(Input.GetTouch(0).position);
+
+        if (Input.accelerationEventCount > 0)
+            Debug.Log(Input.GetAccelerationEvent(0).acceleration);
     }
 }
 ```

--- a/src/Microsoft.Unity.Analyzers.Tests/NonAllocatingArrayAccessTests.cs
+++ b/src/Microsoft.Unity.Analyzers.Tests/NonAllocatingArrayAccessTests.cs
@@ -14,15 +14,19 @@ public class NonAllocatingArrayAccessTests : BaseCodeFixVerifierTest<NonAllocati
 	[InlineData("Collision", "value.contacts.Length", "value.contactCount", "contacts", "contactCount")]
 	[InlineData("Collision2D", "value.contacts.Length", "value.contactCount", "contacts", "contactCount")]
 	[InlineData("object", "Input.touches.Length", "Input.touchCount", "touches", "touchCount")]
+	[InlineData("object", "Input.accelerationEvents.Length", "Input.accelerationEventCount", "accelerationEvents", "accelerationEventCount")]
 	[InlineData("Collision", "value.contacts[i]", "value.GetContact(i)", "contacts", "GetContact")]
 	[InlineData("Collision2D", "value.contacts[i]", "value.GetContact(i)", "contacts", "GetContact")]
 	[InlineData("object", "Input.touches[i]", "Input.GetTouch(i)", "touches", "GetTouch")]
+	[InlineData("object", "Input.accelerationEvents[i]", "Input.GetAccelerationEvent(i)", "accelerationEvents", "GetAccelerationEvent")]
 	[InlineData("Collision", "value.contacts[0].normal", "value.GetContact(0).normal", "contacts", "GetContact")]
 	[InlineData("Collision2D", "value.contacts[0].normal", "value.GetContact(0).normal", "contacts", "GetContact")]
 	[InlineData("object", "Input.touches[0].position", "Input.GetTouch(0).position", "touches", "GetTouch")]
+	[InlineData("object", "Input.accelerationEvents[0].acceleration", "Input.GetAccelerationEvent(0).acceleration", "accelerationEvents", "GetAccelerationEvent")]
 	[InlineData("Collision", "value.contacts[i++]", "value.GetContact(i++)", "contacts", "GetContact")]
 	[InlineData("Collision2D", "value.contacts[i++]", "value.GetContact(i++)", "contacts", "GetContact")]
 	[InlineData("object", "Input.touches[i++]", "Input.GetTouch(i++)", "touches", "GetTouch")]
+	[InlineData("object", "Input.accelerationEvents[i++]", "Input.GetAccelerationEvent(i++)", "accelerationEvents", "GetAccelerationEvent")]
 	public async Task NonAllocatingRead(string type, string expression, string fixedExpression, string property, string replacement)
 	{
 		var test = Source(type, $"Debug.Log({expression});");
@@ -70,10 +74,14 @@ public class NonAllocatingArrayAccessTests : BaseCodeFixVerifierTest<NonAllocati
 	[InlineData("Collision2D", "Debug.Log(value.GetContact(i));")]
 	[InlineData("object", "Debug.Log(Input.touchCount);")]
 	[InlineData("object", "Debug.Log(Input.GetTouch(i));")]
+	[InlineData("object", "Debug.Log(Input.accelerationEventCount);")]
+	[InlineData("object", "Debug.Log(Input.GetAccelerationEvent(i));")]
 	[InlineData("Collision", "Debug.Log(value.contacts);")]
 	[InlineData("object", "Debug.Log(Input.touches);")]
+	[InlineData("object", "Debug.Log(Input.accelerationEvents);")]
 	[InlineData("Collision", "foreach (var contact in value.contacts) Debug.Log(contact);")]
 	[InlineData("object", "foreach (var touch in Input.touches) Debug.Log(touch);")]
+	[InlineData("object", "foreach (var accelerationEvent in Input.accelerationEvents) Debug.Log(accelerationEvent);")]
 	[InlineData("Collision", "Debug.Log(value.contacts.LongLength);")]
 	[InlineData("Collision", "Debug.Log(nameof(value.contacts.Length));")]
 	[InlineData("object", "Debug.Log(nameof(Input.touches.Length));")]
@@ -96,6 +104,8 @@ public class NonAllocatingArrayAccessTests : BaseCodeFixVerifierTest<NonAllocati
 	[InlineData("object", "void Inspect(in Touch touch) { } Inspect((Input.touches[i]));")]
 	[InlineData("Collision", "Debug.Log(value.contacts[i].ToString());")]
 	[InlineData("object", "Input.touches[i].position = Vector2.zero;")]
+	[InlineData("object", "Input.accelerationEvents[i] = default;")]
+	[InlineData("object", "void Modify(ref AccelerationEvent accelerationEvent) { } Modify(ref Input.accelerationEvents[i]);")]
 	[InlineData("object", "Input.touches[i]!.position = Vector2.zero;")]
 	[InlineData("Collision", "ref var contact = ref value.contacts[i]!; Debug.Log(contact);")]
 	[InlineData("object", "Input.touches[i].tapCount++;")]
@@ -103,6 +113,7 @@ public class NonAllocatingArrayAccessTests : BaseCodeFixVerifierTest<NonAllocati
 	[InlineData("Collision", "Debug.Log(value.contacts[(long)i]);")]
 	[InlineData("Collision2D", "Debug.Log(value.contacts[(uint)i]);")]
 	[InlineData("object", "Debug.Log(Input.touches[(long)i]);")]
+	[InlineData("object", "Debug.Log(Input.accelerationEvents[(long)i]);")]
 	public async Task NotAValueReadWithIntIndex(string type, string statement)
 	{
 		await VerifyCSharpDiagnosticAsync(Source(type, statement));

--- a/src/Microsoft.Unity.Analyzers/NonAllocatingArrayAccess.cs
+++ b/src/Microsoft.Unity.Analyzers/NonAllocatingArrayAccess.cs
@@ -41,7 +41,8 @@ public class NonAllocatingArrayAccessAnalyzer : DiagnosticAnalyzer
 	private static readonly Dictionary<string, (Type[] Types, string Count, string Element)> Candidates = new()
 	{
 		["contacts"] = ([typeof(UnityEngine.Collision), typeof(UnityEngine.Collision2D)], "contactCount", "GetContact"),
-		["touches"] = ([typeof(UnityEngine.Input)], "touchCount", "GetTouch")
+		["touches"] = ([typeof(UnityEngine.Input)], "touchCount", "GetTouch"),
+		["accelerationEvents"] = ([typeof(UnityEngine.Input)], "accelerationEventCount", "GetAccelerationEvent")
 	};
 
 	public override void Initialize(AnalysisContext context)


### PR DESCRIPTION
#### Checklist
- [x] I have read the [Contribution Guide](https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/main/CONTRIBUTING.md).
- [x] This extends UNT0045; the approved-issue requirement for a new analyzer or suppressor does not apply.
- [x] I have added tests that prove the extension works.
- [x] I have updated the user-facing documentation.

#### Short description of what this resolves:

Extend UNT0045 to cover the legacy `Input.accelerationEvents` array using the existing analyzer and fixer:

```csharp
Input.accelerationEvents.Length  // -> Input.accelerationEventCount
Input.accelerationEvents[index] // -> Input.GetAccelerationEvent(index)
```

#### Changes proposed in this pull request:
- Add one entry to the existing candidate map. Detection and code-fix logic are unchanged.
- Extend the parameterized tests for count/element reads, member access, index side effects, already non-allocating calls, whole-array usage, writes, reference arguments, and unsupported indices.
- Add the new replacements and before/after examples to `doc/UNT0045.md`.

#### Validation

The test project builds without warnings or errors, all 67 `NonAllocatingArrayAccessTests` cases pass, and the Husky pre-commit formatting task completed successfully.